### PR TITLE
fix(license): LICENSE 改为纯 AGPL-3.0 官方全文以修复 GitHub 识别

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,12 +1,3 @@
-Claude Chat Mobile
-Copyright (C) 2026 Ike-li
-
-Licensed under the GNU Affero General Public License, version 3 (AGPL-3.0-only),
-supplemented by additional terms under Section 7 of that license. The additional
-terms are stated in the NOTICE file distributed with this program.
-
-================================================================================
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 


### PR DESCRIPTION
## 问题
上一版 `LICENSE` 顶部有 4 行 prose 头部（项目名 + 指向 NOTICE 的说明），导致 GitHub Licensee 连续 5 分钟识别为 **Other / NOASSERTION**——内容哈希不匹配、prose 也拉低了相似度匹配。

## 修复
`LICENSE` 现为 gnu.org 的 **AGPL-3.0 官方全文、逐字节相同**（本地 `diff` 验证为空）→ Licensee 内容哈希精确匹配 → 必然识别为 `AGPL-3.0`。

版权声明与 Section 7 附加条款的指向仍保留在 `NOTICE` 与 `README`（AGPL Section 7 允许把"指向附加条款所在处的通知"置于他处），许可与附加条款效力不变。

## 验证
- 本地：`diff LICENSE <gnu.org 官方全文>` == 空
- 合并后：确认 GitHub 侧栏识别为 `AGPL-3.0`
