### PR TITLE
docs(readme): link to the landing page (GitHub Pages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Use your real local `claude` CLI from your phone — as if you were sitting at your own terminal.
 
-**English** · [中文](README.zh-CN.md)
+🌐 **[Website](https://ike-li.github.io/claude-chat-mobile/)** · **English** · [中文](README.zh-CN.md)
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](package.json)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 > 从手机上使用真正的 `claude` CLI——就像你正坐在自己的终端前。
 
-[English](README.md) · **中文**
+🌐 **[网站](https://ike-li.github.io/claude-chat-mobile/)** · [English](README.md) · **中文**
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](package.json)


### PR DESCRIPTION
## What

Adds a 🌐 Website link to the top of `README.md` and `README.zh-CN.md`, pointing to the GitHub Pages landing site.

## Note

The link goes live once **Settings → Pages** is enabled (Deploy from a branch → `master` / `/docs`) — until then it 404s. The landing page itself landed in #5.
