### PR TITLE
ci(pages): 发布改用 GitHub Actions 部署 + preview:landing 脚本

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,37 @@
+# 发布 docs/ 静态 landing page 到 GitHub Pages。
+# 取代此前的 legacy(分支)构建：那条管线不透明（失败只报 "Page build failed."、无日志）
+# 且首次开启时抖动过两次。改用官方 Actions 部署后，每次 push 都有完整构建日志 + 明确成败。
+# 本地预览（所见即所得，因 docs/ 有 .nojekyll、GitHub 不做任何转换）：npm run preview:landing
+name: deploy-pages
+
+on:
+  push:
+    branches: [master]
+    paths: ['docs/**']        # 只有 landing 内容变了才重新部署
+  workflow_dispatch:          # 也可在 Actions 页手动触发（首次部署 / 强制重发）
+
+# GITHUB_TOKEN 权限：读代码 + 写 Pages + OIDC 身份（deploy-pages 要求）
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 同一时刻只跑一个部署；不打断进行中的那个（避免半成品覆盖线上）
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs               # 直接把 docs/ 整个作为站点根发布
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test:unit": "node --test test/*.test.mjs",
     "test:integration": "node --test --test-force-exit test/integration/*.test.mjs",
     "test:coverage": "node --experimental-test-coverage --test test/*.test.mjs",
-    "test:visual": "node scripts/visual-e2e-runner.js"
+    "test:visual": "node scripts/visual-e2e-runner.js",
+    "preview:landing": "python3 -m http.server -d docs 8000"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.0",


### PR DESCRIPTION
## 为什么

GitHub Pages 的 legacy(分支)构建对 `docs/` 静态 landing 不透明——失败只报一句 `Page build failed.`、零日志，且首次开启时抖动失败两次才在第三次成功。以后更新 landing 想快速排障很难。

## 改动

- **`.github/workflows/deploy-pages.yml`**：官方 `actions/upload-pages-artifact` + `actions/deploy-pages`，把 `docs/` 整个作为站点根发布。今后每次 push（仅当 `docs/**` 变动）都有**完整构建日志 + 明确 ✅/❌**；也支持 `workflow_dispatch` 手动触发。
- **`npm run preview:landing`**：`python3 -m http.server -d docs`，本地**所见即所得**预览（`docs/` 有 `.nojekyll`、GitHub 不做任何转换，本地渲染 = 线上）。

## 合并后

1. Pages 源 legacy → GitHub Actions（API 一条命令，可逆）
2. `workflow_dispatch` 触发首次 Actions 部署
3. 验证 https://ike-li.github.io/claude-chat-mobile/ 仍 200 且是真 landing 页

## 安全

workflow 无 `run:` shell 步骤、无任何 `github.event.*` 不可信输入，唯一 `${{ }}` 是可信 action 输出 `page_url`——无注入面。
