### PR TITLE
[codex] test P0 auth failure UI

### DIFF
--- a/scripts/visual-mock-server.js
+++ b/scripts/visual-mock-server.js
@@ -13,6 +13,16 @@ const httpServer = createServer(app);
 const io = new Server(httpServer, {
   cors: { origin: '*' }
 });
+const REJECTED_AUTH_TOKENS = new Set(['bad-token', 'invalid-token', 'expired-token']);
+
+io.use((socket, next) => {
+  const token = socket.handshake.auth?.token;
+  if (REJECTED_AUTH_TOKENS.has(token)) {
+    next(new Error('unauthorized'));
+    return;
+  }
+  next();
+});
 
 // Calculate asset version finger-print to bypass caching (matching server.js)
 const SELF_JS_DIR = join(HERE, '../public', 'js');

--- a/specs/README.md
+++ b/specs/README.md
@@ -24,6 +24,7 @@ Current P0 mock-only coverage also includes:
 
 - `test:settings-echo` in the visual mock server, which renders the selected model, permission mode, and thinking effort from the next sent message so the settings panel is tested through user-visible chat behavior.
 - A mock `logs:get` response with a stable `[MOCK_LOG]` trace row so the Console modal can verify Clear affects only the log pane, not chat history.
+- Visual mock Socket.IO auth rejects `bad-token`, `invalid-token`, and `expired-token` with `unauthorized` so P0 can cover the token retry UI without enabling production `AUTH_TOKEN`.
 - Client-side attachment boundary checks for oversized files and repeated same-file selection; these do not upload to the real server or touch Claude.
 
 ## Test Plan

--- a/tests/p0/security-observable-ui.spec.ts
+++ b/tests/p0/security-observable-ui.spec.ts
@@ -26,4 +26,32 @@ test.describe('P0 日常零 token Mock UI 回归', () => {
 
     await expectNoBrowserErrors(page);
   });
+
+  test('P0-20b 鉴权失败显示令牌输入页且重输后恢复连接', async ({ page }) => {
+    const consoleText: string[] = [];
+    captureBrowserErrors(page);
+    page.on('console', message => consoleText.push(message.text()));
+    await page.request.post('/__reset');
+
+    await page.goto('/#token=bad-token');
+    await expect.poll(() => page.url()).not.toContain('bad-token');
+    await expect(page.locator('#authGate')).toBeVisible();
+    await expect(page.locator('#authError')).toContainText('令牌无效，请重新输入');
+    await expect(page.locator('#connDot')).not.toHaveClass(/bg-success/);
+    await expect(page.locator('[data-testid="user-message"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="assistant-message"]')).toHaveCount(0);
+    await expect(page.locator('body')).not.toContainText('bad-token');
+    expect(consoleText.join('\n')).not.toContain('bad-token');
+
+    await page.locator('#authToken').fill('mock-token');
+    await page.locator('#authSubmit').click();
+    await expect(page.locator('#authGate')).toBeHidden();
+    await expect(page.locator('#connDot')).toHaveClass(/bg-success/);
+    await expect(page.locator('#input')).toBeVisible();
+    await expect(page.locator('body')).not.toContainText('mock-token');
+    expect(await page.evaluate(() => localStorage.getItem('auth_token'))).toBe('mock-token');
+    expect(consoleText.join('\n')).not.toContain('mock-token');
+
+    await expectNoBrowserErrors(page);
+  });
 });


### PR DESCRIPTION
## What changed

- Added a P0 mock regression for invalid AUTH_TOKEN handling in the mobile UI.
- Taught the visual mock Socket.IO server to reject `bad-token`, `invalid-token`, and `expired-token` with `unauthorized`.
- Documented the mock-only auth failure boundary in `specs/README.md`.

## Why

P0-20 already covered token hash cleanup and token redaction, but it did not exercise the user-visible unauthorized path. This adds a zero-token, mock-only regression for the retry screen and successful reconnect after re-entering a valid token.

## Validation

- `npm run check`
- `npx playwright test --list`
- `npm run test:playwright:p0` (24 passed)
- `git diff --check`
