### PR TITLE
chore(deps): npm audit fix 清掉 4 条依赖告警（仅传递依赖，直接依赖不动）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -330,13 +330,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -409,13 +409,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -644,20 +644,20 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -667,17 +667,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -1385,9 +1398,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
把 v1.4.0 发版时 GitHub 报出的依赖告警清掉。**这也是「发版走 PR」的第一次实践**——此前 `scripts/release.sh` 直接 push 双分支，每次都在 bypass 分支保护的「必须走 PR」规则。

## 改了什么

只动 `package-lock.json`，`package.json` 一行没改：

| 包 | 变更 | 位置 |
|---|---|---|
| `@modelcontextprotocol/sdk` | 1.29.0 → 1.30.0 | 传递依赖 |
| `@hono/node-server` | 1.19.14 → 2.0.12 | 传递依赖 |
| `fast-uri` | 3.1.3 → 3.1.4 | 传递依赖 |
| `body-parser` | 2.2.2 → 2.3.0 | 传递依赖 |
| `brace-expansion` | 5.0.7 → 5.0.9 | dev 传递依赖 |

`express@5.2.1` 与 `@anthropic-ai/claude-agent-sdk@0.3.201` 两个直接依赖保持原样。

## 实际风险：本项目当前形态下四条都不可利用

逐条核过触发条件，不是「看着像 dev 依赖就放过」：

- **`fast-uri` (high)** — 链路 `agent-sdk → MCP SDK → ajv → fast-uri`，ajv 用它解析 JSON Schema 的 `$ref`/`$id`。要利用得先喂进恶意 schema，而 schema 来自用户自己配置的 MCP server；叠加本服务是单用户自托管 + AUTH_TOKEN + 设备审批，外部触达不到。
- **`@hono/node-server` (moderate)** — advisory 明写是 **Windows** 上经 `%5C` 的 `serve-static` 路径穿越。本项目部署在 macOS LaunchAgent / Linux systemd，不适用。
- **`body-parser` (low)** — 触发条件是配了**无效**的 limit 值导致大小限制静默失效。本项目唯一用点 `src/server/http.js:274` 是 `express.json({ limit: '4kb' })`，合法值，且路由带 `httpAuth`。
- **`brace-expansion` (high)** — `eslint → minimatch` 的纯 dev 依赖，不进生产。

仍然修的理由：真实风险为零，但告警长期挂在仓库首页，对面向大众自托管的开源项目是实打实的观感成本，而代价只是几个传递依赖的小版本升级。

## 验证

重点在 SDK——MCP SDK 升了 minor、`@hono/node-server` 跨了大版本，而**单测与 E2E 全是 mock，覆盖不到真 SDK**。所以实跑了一次真 turn：

```
system/init → assistant → rate_limit_event → result/success   (13.6s)
```

其余：

- `npm audit` → found 0 vulnerabilities
- `npm run check` 全绿
- `CI=true npm test` → 2259 tests / 0 fail / 0 cancelled
- `npm run test:e2e` → 218 passed
- 本机 `npm test` → 9 fail，与修复前逐条一致（`auth-token`/`cf-access` 的既有 `.env` 环境问题，非本次引入）

## 合并方式提醒

`master` 目前是 `dev` 的直接祖先，可 ff。GitHub 的 "Rebase and merge" 会重写 commit hash，导致两分支历史分叉、后续 `dev → master` 的 ff 失效。若要保持线性且不分叉，合并后需把本地 `dev` 同步到 `master`。