### PR TITLE
dev → master：README 重构、/js 预读优化、CI 权限收窄、依赖告警清理

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches: [master, dev]
   pull_request:
 
+# 两个 job 都只做 checkout/setup-node/npm/upload-artifact，不写回仓库任何东西，
+# 所以把 GITHUB_TOKEN 收到最小面。（upload-artifact 走 ACTIONS_RUNTIME_TOKEN，不吃这里的权限。）
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 # Claude Chat Mobile
 
-> Bridge your local `claude` CLI to your phone: same agent, same session log, same permissions and tools — not a remote desktop, and not a shared live TTY.
+> Connect your local `claude` CLI to your phone. It keeps the same project configuration, tools, and session history, but it is not remote desktop software or a shared live TTY.
 
 [中文](README.md) · **English** · [🌐 Website](https://ike-li.github.io/claude-chat-mobile/)
 
@@ -11,34 +11,52 @@
 [![PWA](https://img.shields.io/badge/PWA-installable-blueviolet.svg)](#quick-start)
 [![CI](https://github.com/Ike-li/claude-chat-mobile/actions/workflows/test.yml/badge.svg)](https://github.com/Ike-li/claude-chat-mobile/actions/workflows/test.yml)
 
-> The two version badges read `master`'s `package.json` directly — they are not hand-maintained: Agent SDK comes from `dependencies`, claude CLI from `verifiedWith.claudeCli` (recorded by `scripts/release.sh` at release time). **The claude CLI one says "which version the last release was verified against", not a requirement** — this project drives *your* local CLI, and which version you run is your call.
+> The Agent SDK and claude CLI badges read `package.json` on `master`. The CLI badge records the environment used to verify the latest release; it is not a minimum version requirement.
 
-**Claude Code keeps running, but you're not always at your computer.** You ask claude to change code, then leave for a meeting — when it needs permission, a push arrives on your phone; open the app to see details and allow or deny. Back at your desk, `/resume` in the terminal picks up the same session you continued from your phone — same agent, same log, not a new one.
+![Claude Chat Mobile — use your terminal claude from your phone](https://ike-li.github.io/claude-chat-mobile/assets/hero-en.jpg)
 
-This project is for people who already use the `claude` CLI in a terminal. It does not bundle Claude, and it is not a reimplementation. It drives your logged-in local CLI through the [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview). The phone sees the same agent, the same `CLAUDE.md`, the same MCP servers, skills, hooks, and session logs.
+Claude Code may keep running while you are away from your computer. Claude Chat Mobile drives your locally authenticated CLI through the [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview), so you can keep editing code, running commands, answering questions, and approving actions from your phone. It does not bundle Claude or create a separate account or session system.
 
-The goal is narrow: **edit code, run commands, approve dangerous actions, and resume earlier conversations from your phone**. Both sides read the same on-disk CLI session log, but this is **not** a screen mirror of your terminal, and **not** a shared TTY where both ends type into the same session at once — only one driver (Web or CLI) writes at a time; the other side is read-only catch-up. While the CLI is running, the Web UI defaults to a read-only mirror; takeover waits for the current turn to finish before writing.
+## Who it is for
 
-## When it's worth it
+- People who already use `claude` in a macOS or Linux terminal and want to follow or handle work away from the desk.
+- People who need to switch between repositories and sessions while seeing tool calls, diffs, background tasks, and errors on a phone.
+- People who want approvals and questions to reach the phone instead of watching a terminal continuously.
 
-> This is not a phone remote desktop. A remote desktop mirrors your computer screen; this gives your local `claude` session a phone entry point. The difference shows up in situations like these:
->
-> - **A task is running and you have left the computer.** You ask claude to change code, then leave for a meeting. When it needs permission, a push arrives on your phone (type-level copy such as "needs your approval: Edit" — **not** the full command text; open the app to see details and allow/deny). No need to keep the computer screen awake or open a remote terminal.
-> - **One session, picked up across devices.** Start something from your phone on the way out; resume it at your desk with `/resume` — both sides read the same CLI session log, not two separate conversations. The other way works too: while a session runs in the terminal, the phone can open it as a **read-only mirror** (catch-up from the on-disk transcript; short blank windows or delay are normal — it does not attach to the live process). To keep writing from the phone, take over after the current turn ends. On a flaky subway connection the Web page reconnects and replays buffered output.
-> - **Several repos in parallel.** claude can run different tasks in two projects at once. Switch among them via the phone home hub / workspace drawer / session list (not a browser multi-tab mental model). A single remote-desktop screen is awkward for that on a phone.
-> - **Phone-native input.** Type `/` for a tappable command list, send a photo from your library to claude, or long-press to copy a long output. These interactions fit a phone better than a tiny terminal.
->
-> If you only need to glance at the machine now and then, a remote desktop is enough. This project is for using the phone often as a terminal companion.
+Only one side drives a session at a time. Web-driven messages travel through the Agent SDK into the local CLI. When the terminal CLI is driving, the Web app follows the persisted transcript in read-only mode. This is not screen sharing, and the phone and terminal cannot both type into one live process.
+
+## Core capabilities
+
+### Sessions and workspaces
+
+- Resume, fork, and remove CLI sessions at two levels, with a cross-session “needs you” view.
+- Monitor multiple workspaces and sessions. A git worktree must be added to `workdirs.json` by absolute path; it is never auto-discovered or implicitly authorized.
+- One message per turn: while a task runs, you can keep a draft, but the send control becomes Stop instead of queuing another message.
+
+### Mobile interaction
+
+- Streaming Markdown, syntax highlighting, tool cards, Edit/Write diffs, Read excerpts, and a native `AskUserQuestion` picker.
+- Image and file uploads, pasted screenshots, historical attachment previews, and composer `@` file references.
+- Browse files inside approved workspaces. Existing text files up to 256KB can be edited in CodeMirror, with content-hash checks preventing concurrent overwrites.
+
+### Notifications and visibility
+
+- Web Push / ntfy notifications for approvals, questions, and results. Notifications default to type-only text; you can test the delivery path and optionally enable content previews for Web Push.
+- An optional CLI hooks bridge turns terminal Stop / Notification events into immediate signals instead of waiting for polling.
+- API errors, retry countdowns, SDK notices, subagents, and background-task progress are visible in the UI rather than only in server logs.
+
+### Reliability and operations
+
+- `seq + epoch` event deduplication and reconnect replay. The status line selects either SDK or CLI snapshots according to the current driver.
+- Startup checks with `doctor`, an in-app security check, redacted logs, auth rate limits, a service-status panel, and authenticated `/health` and `/metrics` endpoints.
+- An installable PWA with complete Chinese and English UI coverage. Browser dependencies are self-hosted with the project instead of loaded from a CDN.
 
 ## Prerequisites
 
-- **Node.js ≥ 20** — check with `node --version`.
-- **A working `claude` CLI on the host.** This project drives *your* local CLI; it ships nothing of its own. Confirm `claude` runs in your terminal first (`which claude`, then open a conversation to confirm you are logged in). The web UI inherits that CLI, your `CLAUDE.md`, MCP servers, skills, hooks, and shell environment.
-- **Official subscription, or a third-party gateway / relay API — both work.** The web side inherits the provider / gateway / model from **the shell that starts the server**:
-  - **Official subscription** (`claude` already logged in): no extra setup.
-  - **Third-party gateway / relay**: `export` the `ANTHROPIC_*` your gateway needs (typically `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_MODEL`, per your gateway's docs) in the shell that starts the server, then launch it.
-  - ⚠️ Putting `ANTHROPIC_*` in `.env` has **no effect**. They are stripped at startup; only the server's shell environment is read.
-- **macOS or Linux (first-class).** Some path/permission logic has Windows-oriented fixes, but Windows is **not** an officially supported platform. Treat native Windows as experimental; WSL2 is the more reliable path.
+- **Node.js 20 or newer.**
+- **A locally installed and authenticated `claude` CLI.** Confirm that `which claude` finds it and that a terminal conversation works.
+- **macOS or Linux** are first-class platforms. Native Windows is experimental; WSL2 is the safer route.
+- Claude subscriptions and third-party gateways are both supported. Gateway `ANTHROPIC_*` variables must exist in the **shell that starts the server**; values placed in `.env` are stripped.
 
 ## Quick Start
 
@@ -46,200 +64,81 @@ The goal is narrow: **edit code, run commands, approve dangerous actions, and re
 git clone https://github.com/Ike-li/claude-chat-mobile.git
 cd claude-chat-mobile
 
-node --version           # need Node ≥ 20
-which claude             # the CLI this project drives — must be installed & logged in
-
-npm install --omit=dev   # runtime deps only — no Playwright/browser. Use a full install for UI tests.
-npm run setup            # interactive wizard: generates AUTH_TOKEN (the #1 gotcha) + asks for WORK_DIR, writes .env (0600)
-                         # prefer this over hand-editing; to use the raw template instead: cp .env.example .env
-                         # for scripts/agents, use non-interactive mode (the wizard needs a TTY):
-                         #   node scripts/setup.js --yes --work-dir=<absolute-path> [--hooks=on|off] [--force]
-
-# Recommended: pre-flight your config (port in use, CLAUDE_BIN path, gateway env, file perms)
-node scripts/doctor.js        # check config
-node scripts/doctor.js --fix  # tighten perms (.env and CCM_DATA_DIR/*.json → 0600)
-
-npm start                     # http://localhost:3000
+node --version
+which claude
+npm install --omit=dev
+npm run setup
+node scripts/doctor.js
+npm start
 ```
 
-**Faster: hand it to your coding agent** — in the repo directory (or have it clone first), give this to Claude Code / Codex CLI or similar:
+`setup` creates an `AUTH_TOKEN`, asks which `WORK_DIR` Claude may access, and explicitly asks whether to install the CLI hooks bridge. The startup log prints a tokenized LAN URL that you can open on your phone.
 
-```
-Help me install and start claude-chat-mobile for the first time (a web UI that connects my local claude CLI
-to my phone). This is a fresh, first-time setup, not restarting an already-deployed daemon — the "production
-deployment: don't manually npm start" warning in CLAUDE.md doesn't apply here.
-
-Do these in order, confirming each step before moving on:
-
-1. Prerequisites: node --version must be >= 20; which claude must resolve and be logged in (that CLI is what
-   this project drives — it ships none of its own). If either fails, stop and tell me; don't install claude
-   yourself.
-2. npm install --omit=dev
-3. Check two things with me before continuing:
-   (a) Which directory to mount as WORK_DIR — give an absolute path. This is what I'll be able to let claude
-       read and write from my phone, so don't use my whole home directory.
-   (b) Whether to install the CLI hooks bridge — it lets sessions I run in my own terminal push to my phone,
-       at the cost of writing to my global ~/.claude/settings.json.
-4. Write the config non-interactively; do NOT run the interactive wizard (your shell has no TTY, so it stalls
-   on a prompt, silently does nothing, and still exits 0):
-   node scripts/setup.js --yes --work-dir=<the absolute path from step 3> --hooks=<on or off>
-5. node scripts/doctor.js and fix what it flags (permission issues: node scripts/doctor.js --fix).
-6. Start the server in the background, not in the foreground (it would block you forever). Once up, confirm
-   with curl -s "http://127.0.0.1:3000/health?token=<AUTH_TOKEN from .env>" and require real JSON back —
-   don't just check that a process exists.
-7. Tell me how to open it on my phone: give me the LAN URL with the token from the startup log. Note that
-   AUTH_TOKEN is a secret (holding it is equivalent to shell access on this machine); it lives in .env
-   (mode 0600), so don't put it anywhere that leaves this machine.
-8. The first time my phone connects it will be blocked on device-fingerprint approval (a valid token is not
-   enough). When that happens, run node scripts/device.js list, confirm it's my phone, then
-   node scripts/device.js approve <ID>.
-
-If I later want fixed-domain public access, use docs/deployment.md to help me set that up.
-```
-
-Sessions started from the web work out of the box with the SDK status line — no Claude config changes needed. If you also want the web UI to mirror the CLI's model, thinking effort, context, cost, and quota while **read-only viewing a session that's actually running in the CLI**, you can explicitly install the transparent statusline bridge:
+The first connection from a non-local device also requires approval on the computer:
 
 ```bash
-npm run statusline:status     # read-only check, does not modify ~/.claude
-npm run statusline:install    # explicit opt-in; never run automatically by npm install / npm start
+node scripts/device.js list
+node scripts/device.js approve <ID>
 ```
 
-After installing, restart your Claude CLI and the background server; uninstall with `npm run statusline:uninstall`.
-
-Then open it on your phone. The startup log prints usable URLs with the token pre-filled:
-
-- **Same WiFi:** set `AUTH_TOKEN` in `.env` first (required even on your LAN; without it the phone cannot connect), then open the LAN address printed at startup (`http://<lan-ip>:3000/#token=…`). No tunnel needed.
-- **Public internet / install as a PWA** (PWA needs https): run a tunnel in another terminal:
-
-```bash
-cloudflared tunnel --url http://localhost:3000
-# On your phone open https://<random>.trycloudflare.com/#token=<YOUR_AUTH_TOKEN>
-# The token is stored in localStorage on first load, then cleared from the address bar.
-```
-
-The first time a phone connects from a non-local path, **a valid token alone is not enough** — approve the device fingerprint once on the computer (TOFU):
-
-```bash
-node scripts/device.js list           # list pending devices
-node scripts/device.js approve <ID>   # unlock that device immediately
-```
-
-> ⚠️ With no `AUTH_TOKEN` set, the server binds to `127.0.0.1` only. Neither your phone on the same LAN nor a tunnel can reach it. This is deliberate.
->
-> 📌 The above is the minimal setup: a temporary random tunnel for testing. For a fixed domain, Cloudflare Access two-factor, and a background daemon, see [docs/deployment.md](docs/deployment.md). Connections that pass Cloudflare Access skip the device-fingerprint step; a temporary random `cloudflared` tunnel has **no** Access, so you still need `device.js approve`.
->
-> ⚠️ This is a remotely reachable code-execution channel into your local shell. Read the [Security Model](#security-model) below before exposing it to the public internet.
+For the complete first-run flow, non-interactive setup, a copyable coding-agent prompt, PWA setup, and bridge configuration, see the [Getting Started guide](docs/getting-started.en.md).
 
 ## Three ways to run it
 
-Pick one for your situation. Commands are in [Quick Start](#quick-start) above and [docs/deployment.md](docs/deployment.md):
-
-| Mode | Good for | Cost |
+| Mode | Best for | Notes |
 |---|---|---|
-| **LAN, same WiFi**: `http://<lan-ip>:3000/#token=` | At home, phone and computer on one network | Useless when out; no tunnel, least fuss |
-| **Temporary public**: `cloudflared tunnel --url` (random domain) | Quick trial / demo | Address changes on every restart; testing-only per Cloudflare; device approval still required |
-| **Fixed production**: fixed domain + Cloudflare Access 2FA + daemon | Long-term, anywhere access | One-time DevOps setup; see [docs/deployment.md](docs/deployment.md) |
+| Same Wi-Fi: `http://<lan-ip>:3000/#token=…` | Home or office LAN | Simplest option; unavailable after leaving that network |
+| Temporary public URL: `cloudflared tunnel --url http://localhost:3000` | Trials and demos | Random hostname changes; no Access layer, so device approval still applies |
+| Fixed production deployment: domain + Cloudflare Access + service manager | Long-term access from anywhere | Requires one-time operations setup; see the [deployment guide](docs/deployment.md) |
+
+PWA installation and Web Push require HTTPS. On iOS, Web Push also requires iOS 16.4+ and installing the site on the Home Screen first.
 
 ## Security Model
 
-> **Read this before exposing it to the public internet.** This is a remotely reachable code-execution channel into your local shell:
+> This is a remotely reachable code-execution path into your local shell. Understand these boundaries before exposing it publicly.
 
-1. **Single-user per instance.** You run your own instance for yourself. There is no multi-user, account, or login system; any request that passes auth has the same power as you at the terminal. Do not treat it as a multi-tenant service.
-2. **No token, no leaving the host.** With no `AUTH_TOKEN` set, the server binds to `127.0.0.1` only. There is no "empty = open to the world" path. Reaching the public internet *requires* a token.
-3. **The auto-approve set inherits the CLI; no second allow-list is injected.** This project does not inject its own `allowedTools` / `disallowedTools`. Auto-approve is exactly the merged `permissions.allow` from your existing claude config: global `~/.claude/settings.json`, project `.claude/settings.json`, and local `.claude/settings.local.json` (loaded via `settingSources`, same source as your terminal). A match is auto-approved; anything else is suspended and pushed to the phone — the **full command and working directory are visible inside the app** before you confirm.
-   - The Web UI also has runtime permission modes (including `dontAsk` / `auto` / `bypassPermissions`) and approval TTL behavior; that is **not** "phone UI matches interactive terminal step for step." What is shared is the settings allow-list source, not the full interaction surface.
-   - ⚠️ **Before exposing publicly, audit your global `~/.claude/settings.json` allow-list**. Old `Bash(...)` / `Write` rules from terminal use will auto-approve here too, without a phone prompt. Tighten more than just the project-local config.
-4. **Device trust (TOFU).** A connection that is neither local nor Cloudflare Access-verified must be authorized once on your computer before it can do anything. A valid token alone is not enough. On the computer:
-   ```bash
-   node scripts/device.js list
-   node scripts/device.js approve <ID>
-   ```
-   Revoke with `deny <ID>`. Loopback connections and public connections that already passed a Cloudflare Access JWT skip this step.
+1. **Single-user, owner-level access.** There is no multi-user or tenant isolation. An authenticated operation has the permissions of the local account that started `claude`.
+2. **No token means loopback only.** Without `AUTH_TOKEN`, the server listens only on `127.0.0.1`. Phone or tunnel access requires a strong token.
+3. **Keep workspace scope narrow.** `WORK_DIR` and `workdirs.json` are the scope gate for files, sessions, and git operations. Do not expose your whole home directory for convenience.
+4. **Automatic approval inherits CLI configuration.** `permissions.allow` rules from `~/.claude/settings.json`, project `.claude/settings.json`, and `.claude/settings.local.json` apply here too. Review accumulated Bash/Write rules before public use.
+5. **Device trust is a second gate.** Except for local connections or requests validated by Cloudflare Access JWT, a valid token still needs one-time device approval. Revoke a device with `node scripts/device.js deny <ID>`.
+6. **The file editor is a direct user write.** It does not pass through the Agent tool-approval chain. It can only modify existing files up to 256KB and applies scope checks, content-hash conflict detection, and audit logging. Set `FILE_EDIT=off` for read-only browsing.
 
-## Cost Note
+Report vulnerabilities privately through [GitHub Security Advisories](SECURITY.md), not a public issue.
 
-**Currently (as of 2026-07-20): Agent SDK / `claude -p` usage still draws from your subscription quota, in the same pool as interactive use**. On the official subscription path, this project does not incur separate billing.
+## How Web and CLI work together
 
-Background: Anthropic once announced that, starting 2026-06-15, SDK *headless* usage would move to a separate credit pool (Max 5x $100/month at API rates), but **that change was paused on the day it shipped and never took effect** ([official Help Center](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)). Anthropic says it will rework the plan and give advance notice. This is a pause, not a cancellation.
-
-- **Potential risk**: if the policy is revived, this project's SDK usage would move out of the subscription quota and could hit a separate credit cap. On the author's own path, a rough API-rate equivalent was about **~$716/month** — **personal measurement only, not a product SLA or typical-user figure**; budget from your own usage if the policy returns.
-- **Via a third-party gateway** (`ANTHROPIC_*` exported in the shell): unaffected — you pay the gateway's own rates.
-
-## Features
-
-Beyond the core loop above:
-
-- **Single-driver model**: Web and CLI take turns writing the same session; while the CLI drives, the Web is a read-only mirror (transcript catch-up). Takeover queues until the current turn finishes to avoid concurrent write forks.
-- **Six permission modes** (default / plan / acceptEdits / dontAsk / auto / bypassPermissions), switchable at runtime; approvals carry TTL and integrity binding.
-- **Per-message model switching** (gateway-suffixed names supported); resume can fall back to the last assistant model in the session.
-- **Multi-repo and multi-session**: switch among allow-listed working directories; watch several sessions from the home hub / drawer. To use a git worktree, add its absolute path to `workdirs.json` as its own workspace (hot-reloaded, no restart).
-- **One turn at a time**: no new messages while a task runs (the input stays typable for drafts; the send slot becomes a stop button with a persistent hint); CLI-style live status line and turn-done line.
-- **Visible sub-agents / background tasks**, with stop for background tasks; Task-list tools rendered inline.
-- **File and image upload** (including clipboard paste and pre-send preview), with path injection and traversal protection; historical attachments open on tap; **read-only project file browse** (never outside allow-listed workdirs).
-- **Preview changes on tool cards**: diff for Edit / Write, snippet for Read; base64 redaction and JSON highlighting.
-- **Thinking-effort control**, a **single-source-of-truth status line** (web-driven sessions read from the SDK; an optional bridge lets CLI-driven sessions mirror a CLI snapshot), and **`AskUserQuestion`** as a native picker.
-- **Web Push / ntfy notifications**: type-level prompts for approvals, questions, and results (**no** command/question body); the notification deep-links back to the session (iOS 16.4+ requires Add to Home Screen first; optional ntfy runs self-hosted for more reliable lock-screen delivery). Result-class pushes are skipped while a socket is already online.
-- **Two-level session delete** (remove from product / truly delete underlying files via SDK); cross-session "needs you" aggregation.
-- **Installable PWA**: maskable icon + standalone display, "Add to Home Screen" to use it as an app.
-- **Ops & security hardening**: log sanitization, `0600` atomic writes, a `doctor` startup self-check, **a one-tap UI security check-up (redacted, audits the dangerous allowlist)**, auth rate limiting, optional Cloudflare Access 2FA, `/metrics` and a service-status panel.
-
-## How it works (read only if you want to read or fork the code)
-
-Internally this is a default-locked relay: it connects your local claude CLI, including your CLAUDE.md / MCP / skills / login state, to a phone browser. Sessions stay continuous, the process is visible, and dangerous actions bounce back to the phone for approval. Two paths coexist: **Web-driven** traffic streams through the SDK; **CLI-driven** traffic writes the on-disk transcript and the Web catches up read-only.
-
-```mermaid
-graph LR
-    subgraph Phone
-        UI[public/ single page<br/>chat bubbles · tool cards · approval sheet]
-    end
-    subgraph Internet
-        CF[Cloudflare Tunnel]
-    end
-    subgraph Host
-        S[src/server/ + thin server.js launcher<br/>Express static + Socket.IO contract layer<br/>auth · preflight · device trust · handler guard]
-        A[src/agent/agent.js · AgentSession<br/>long-lived SDK query · permission gate<br/>event envelope seq+epoch · ring buffer]
-        J[(CCM_DATA_DIR/sessions.json<br/>session metadata)]
-        H[catchUpTick<br/>read-only mirror catch-up]
-        SDK[claude-agent-sdk]
-        CLI[local claude CLI<br/>loads your full config]
-        T[(CLI transcript<br/>~/.claude/projects)]
-        FS[(your project files<br/>WORK_DIR)]
-    end
-    UI <-->|"agent:event envelope / user:* events<br/>(event contract, WebSocket)"| CF <--> S
-    S <--> A
-    A <-->|streaming input<br/>Web-driven| SDK <-->|spawn| CLI
-    CLI --> FS
-    CLI -->|CLI-driven direct write| T
-    T -->|poll catch-up| H --> S
-    S --- J
+```text
+Web driver: phone → Socket.io → AgentSession → Agent SDK → local claude CLI → workspace
+CLI driver:  terminal claude → transcript / hooks → server → read-only phone mirror
 ```
 
-### Message flow
+Both paths share persisted CLI session history, not a live TTY. While the terminal CLI is driving, the Web app can only see content that has reached disk. Hooks accelerate “turn ended / needs you” signals; they do not make the terminal process a bidirectionally attached session. Before Web takes over, it waits for the terminal turn to end and absorbs external transcript growth before sending.
 
-**Web-driven (phone sends a message):**
+See the [architecture guide](docs/architecture.en.md) for the component diagram, message flow, single-driver transitions, and reconnect replay.
 
-1. Phone `user:message {text}` → server validates → routes to the target instance `agents.get(instanceId)` (lazy-respawned resume; after `session:new` a FRESH instance is lazily opened only on the first message).
-2. If the disk grew outside the SDK process (the CLI wrote), dispose+resume first to absorb it — prevents context forks.
-3. The text is pushed into the AgentSession's streaming input → SDK → claude CLI works in `WORK_DIR`.
-4. The SDK message stream flows into `map()`: streaming text → `text_delta`, tool calls → `tool_use`/`tool_result`, off-allow-list actions → `permission_request` (suspended, awaiting allow/deny on the phone).
-5. Each event is wrapped in a `{seq, epoch, sessionId, instanceId, cwd, ts, type, payload}` envelope → into a 2,000-entry ring buffer → `io.to('approved').emit` broadcast to approved devices only (the front-end demuxes by `viewingInstanceId`; high-frequency deltas from background sessions are not broadcast to save bandwidth).
-6. Phone reconnects: `sync:since {sessionId, lastSeq, instanceId}` replays the buffer; an `epoch` change means the server swapped the instance, so the client resets its dedup baseline automatically.
+## Documentation
 
-**CLI-driven (terminal owns the session; Web is read-only):**
+- [Getting Started](docs/getting-started.en.md): from clone to the first message sent from your phone.
+- [Deployment and operations](docs/deployment.md) (Chinese): Cloudflare Tunnel, Access, LaunchAgent, and systemd.
+- [Architecture](docs/architecture.en.md): Web/CLI paths, event envelopes, and takeover boundaries.
+- [Display contracts](docs/display-contracts.md) (Chinese): sources of truth for model, effort, and status-line display.
+- [Repository map](docs/repository-map.md): entrypoints, directory roles, and the complete file inventory.
+- [Environment template](.env.example): every runtime setting and its default.
+- [Security policy](SECURITY.md): private vulnerability-reporting instructions.
 
-1. You type to `claude` in a computer terminal; that path does **not** go through this project's Agent SDK child process.
-2. Output is written to the transcript under `~/.claude/projects/`.
-3. The server's `catchUpTick` polls the disk and pushes newly settled messages as a read-only mirror to Web clients that have the session open.
-4. While the mirror lock is held, Web input is restricted (send button becomes resume/explain state); after the terminal is quiet for a while the lock releases and the Web can take over.
+## Usage and compatibility
 
-Runtime dependencies: `@anthropic-ai/claude-agent-sdk`, `express`, `compression`, `socket.io`, `dotenv`, `web-push`, `jose`. Front-end third-party libraries are self-hosted locally in `public/vendor/` (Tailwind/marked/highlight.js/DOMPurify), with no CDN dependency; see [public/vendor/THIRD-PARTY-NOTICES.md](public/vendor/THIRD-PARTY-NOTICES.md).
+As of **2026-07-31**, Agent SDK, `claude -p`, and third-party Agent SDK apps still draw from Claude subscription usage. Anthropic's previously announced separate-credit plan is paused. This policy may change; check the [official notice](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan).
+
+API-key and third-party-gateway costs and limits are set by their providers. The recorded claude CLI version is only a release-verification environment; check [Releases](https://github.com/Ike-li/claude-chat-mobile/releases) before upgrading.
 
 ## License
 
-[GNU AGPL-3.0-only](LICENSE) © 2026 Ike-li, with additional terms under Section 7; see [NOTICE](NOTICE).
+[GNU AGPL-3.0-only](LICENSE) © 2026 Ike-li, with Section 7 additional terms; see [NOTICE](NOTICE).
 
-In short: you are free to use, study, modify, and self-host this software. But if you run a modified version as a network service, the AGPL requires you to release your source under the AGPL as well, and the additional terms require you to preserve the original author attribution and not misrepresent the project's origin. For any use that cannot meet these conditions, please open an issue to discuss.
+You may use, study, modify, and self-host this software. If you offer a modified version as a network service, the AGPL requires you to make the corresponding source available. The additional terms also require attribution and prohibit misrepresenting the project's origin.
 
 ## Friend Links
 
-- [LINUX DO](https://linux.do/) — a Chinese-language developer community (site is in Chinese)
+- [LINUX DO](https://linux.do/)

--- a/README.en.md
+++ b/README.en.md
@@ -13,8 +13,6 @@
 
 > The Agent SDK and claude CLI badges read `package.json` on `master`. The CLI badge records the environment used to verify the latest release; it is not a minimum version requirement.
 
-![Claude Chat Mobile — use your terminal claude from your phone](https://ike-li.github.io/claude-chat-mobile/assets/hero-en.jpg)
-
 Claude Code may keep running while you are away from your computer. Claude Chat Mobile drives your locally authenticated CLI through the [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview), so you can keep editing code, running commands, answering questions, and approving actions from your phone. It does not bundle Claude or create a separate account or session system.
 
 ## Who it is for

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Chat Mobile
 
-> 把本机 `claude` CLI 接到手机：同一 agent、同一会话记录、同一权限与工具配置——不是远程桌面，也不是共享实时 TTY。
+> 把本机 `claude` CLI 接到手机：沿用同一套项目配置、工具与会话记录，但不是远程桌面，也不是共享实时 TTY。
 
 **中文** · [English](README.en.md) · [🌐 网站](https://ike-li.github.io/claude-chat-mobile/)
 
@@ -11,36 +11,52 @@
 [![PWA](https://img.shields.io/badge/PWA-installable-blueviolet.svg)](#快速开始)
 [![CI](https://github.com/Ike-li/claude-chat-mobile/actions/workflows/test.yml/badge.svg)](https://github.com/Ike-li/claude-chat-mobile/actions/workflows/test.yml)
 
-> 上面两个版本徽章直接读 `master` 上的 `package.json`，不是手写的：Agent SDK 取 `dependencies`，claude CLI 取 `verifiedWith.claudeCli`（发版时由 `scripts/release.sh` 记录）。**claude CLI 那条是「上个发布版验证于哪个版本」，不是版本要求**——本项目驱动的是你本机那个 CLI，用什么版本由你决定。
+> Agent SDK 与 claude CLI 徽章直接读取 `master` 上的 `package.json`。CLI 徽章表示上个发布版的验证环境，不是最低版本要求。
 
 ![Claude Chat Mobile — 终端里的 claude，手机上也能用](https://ike-li.github.io/claude-chat-mobile/assets/hero-zh.jpg)
 
-**Claude Code 在跑，人却不总在电脑前。** 你让 claude 改代码，然后去开会——它需要权限时，手机收到推送；点进 App 看清命令、允许或拒绝。回家坐到电脑前，终端 `/resume` 接上手机上那个会话继续——同一个 agent、同一份记录，不是另开一个。
+Claude Code 在跑，人却不总在电脑前。Claude Chat Mobile 通过 [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview) 驱动你本机已登录的 CLI，让你在手机上继续改代码、跑命令、回答问题和审批操作。它不打包 Claude，也不建立第二套账号或会话系统。
 
-这个项目给已经在终端使用 `claude` CLI 的人用。它不打包 Claude，也不是 Claude 的重新实现；它通过 [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview) 驱动你本机已登录的 CLI。手机端拿到的是同一个 agent、同一份 `CLAUDE.md`、同样的 MCP 服务器、技能、hooks 和会话记录。
+## 适合谁
 
-目标很窄：**在手机上改代码、跑命令、审批危险操作、续上之前的对话**。两端读的是同一份 CLI 会话落盘，但**不是**把终端屏幕镜像过来，也**不是**两端同时往同一会话里打字的共享 TTY——同一时刻只有一个驾驶员（Web 或 CLI），另一端只读追平；CLI 正在跑时 Web 默认只读镜像，接管默认等本轮结束后再写。
+- 已经在 macOS 或 Linux 终端使用 `claude`，希望离开电脑后继续查看和处理任务。
+- 需要在多个仓库、多个会话之间切换，并在手机上查看工具调用、diff、后台任务和错误状态。
+- 希望危险操作或问题能主动通知到手机，而不是一直盯着终端。
 
-## 适用场景
+同一时刻只有一个驾驶员：Web 驾驶时消息经 Agent SDK 进入本机 CLI；终端 CLI 驾驶时，Web 只读追平落盘记录。它不是远程桌面，也不能让手机和终端同时向同一个实时进程输入。
 
-> 它不是手机远程桌面。远程桌面镜像电脑屏幕；这里是给本机 `claude` 会话做一个手机入口。差异主要体现在这些场景：
->
-> - **任务在跑，人离开了电脑。** 你让 claude 改代码，然后去开会。它需要许可时，手机收到推送（类型级提示，如「需要你授权：Edit」——**不含**完整命令正文；点进 App 才能看详情并允许/拒绝）。不用让电脑屏幕亮着，也不用远程戳进终端。
-> - **同一个会话，换设备继续。** 路上用手机起个头，到家后在电脑终端 `/resume` 接上——两端读的是同一份 CLI 会话记录，不是各开一个会话。反过来也行：终端里跑着时，手机可打开同一会话做**只读镜像**（磁盘 transcript 追平，可能有短暂空窗/延迟，不是 attach 到同一个活进程）；要在手机上继续写，等本轮结束后接管。地铁信号差时 Web 页会重连并补发缓冲内的输出。
-> - **多个仓库并行看。** claude 可以同时在两个项目里跑不同任务；在手机的首页枢纽 / 工作区抽屉 / 会话列表之间切换进度（不是浏览器多标签页心智）。一块远程桌面屏幕在手机上很难做到这一点。
-> - **手机输入更顺。** 输入 `/` 弹出可点的命令列表，从相册发截图给 claude，长按复制长输出。这些都按手机交互做，而不是把终端缩小。
->
-> 如果只是偶尔远程看一眼，远程桌面就够了。这个项目适合把手机当成终端的随身入口来高频使用。
+## 核心能力
+
+### 会话与工作区
+
+- 续接、分叉和两级删除 CLI 会话；跨会话聚合“需要你”的任务。
+- 多工作区、多会话并行查看。git worktree 必须把绝对路径显式加入 `workdirs.json`，不会自动探测或隐式放行。
+- 一轮一条：任务运行时输入可继续写草稿，但发送键切换为停止键，不会积压待发消息。
+
+### 手机交互
+
+- 流式 Markdown、代码高亮、工具卡片、Edit/Write diff、Read 片段、`AskUserQuestion` 原生选择器。
+- 上传图片与文件、粘贴截图、历史附件预览，以及 composer `@` 文件引用。
+- 在授权工作区内浏览项目文件；不超过 256KB 的现有文本文件可用 CodeMirror 编辑，写前用内容哈希阻止并发覆盖。
+
+### 通知与可见性
+
+- Web Push / ntfy 通知审批、提问和结果；默认只发类型级提示，可测试推送链路并选择是否开启 Web Push 内容预览。
+- 可选 CLI hooks bridge，让终端会话的 Stop / Notification 从轮询升级为即时信号。
+- API 错误、重试倒计时、SDK 提示、子 agent 与后台任务进度直接显示在界面中，不再只藏在服务端日志。
+
+### 可靠性与运维
+
+- `seq + epoch` 事件去重与断线补发；状态栏按当前驾驶方选择 SDK 或 CLI 快照作为事实源。
+- `doctor` 启动自检、UI 安全体检、日志脱敏、鉴权限速、服务状态面板和鉴权后的 `/health`、`/metrics`。
+- 可安装 PWA，完整中英文界面；前端依赖均随项目自托管，不依赖 CDN。
 
 ## 前置条件
 
-- **Node.js ≥ 20**——用 `node --version` 检查。
-- **本机有一个可用的 `claude` CLI。** 本项目驱动*你的*本机 CLI，不自带。先确认 `claude` 能在终端跑起来（`which claude`，再开一次对话确认已登录）；web UI 继承的就是这个 CLI、你的 `CLAUDE.md`、MCP 服务器、技能、hooks 和 shell 环境。
-- **官方订阅、第三方网关 / 中转 API 都支持。** web 端沿用**启动 server 的那个 shell** 里的 provider / 网关 / 模型：
-  - 用**官方订阅**（`claude` 已登录）：无需额外配置。
-  - 用**第三方网关 / 中转**：在启动 server 的 shell 里 `export` 你网关所需的 `ANTHROPIC_*`（通常是 `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_MODEL`，以你网关的文档为准），再启动 server。
-  - ⚠️ `ANTHROPIC_*` 写进 `.env` **无效**：启动期会剥除这些变量，只读取启动 server 的 shell 环境。
-- **macOS 或 Linux（一等支持）。** 部分路径/权限逻辑对 Windows 做了兼容修补，但**不是**官方支持平台；原生 Windows 请当实验路径，更稳的是 WSL2。
+- **Node.js ≥ 20**。
+- **本机已安装并登录 `claude` CLI**；先确认 `which claude` 能找到命令，并能在终端正常开始对话。
+- **macOS 或 Linux** 为一等支持平台；原生 Windows 属实验路径，推荐使用 WSL2。
+- 官方订阅和第三方网关都可用。网关相关 `ANTHROPIC_*` 必须存在于**启动 server 的 shell 环境**；写进 `.env` 会被剥除。
 
 ## 快速开始
 
@@ -48,207 +64,80 @@
 git clone https://github.com/Ike-li/claude-chat-mobile.git
 cd claude-chat-mobile
 
-node --version           # 需 Node ≥ 20
-which claude             # 本项目驱动的 CLI——必须已安装并登录
-
-npm install --omit=dev   # 仅运行依赖——不含 Playwright/浏览器。要跑 UI 测试用完整 npm install。
-npm run setup            # 交互式向导：自动生成 AUTH_TOKEN（头号门槛）+ 询问 WORK_DIR，写入 .env（权限 0600）
-                         # 推荐用它，免去手搓；想直接用原始模板：cp .env.example .env
-                         # 脚本/agent 代跑用非交互模式（向导需要 TTY）：
-                         #   node scripts/setup.js --yes --work-dir=<绝对路径> [--hooks=on|off] [--force]
-
-# 推荐：启动前自检配置（端口占用、CLAUDE_BIN 路径、网关环境、文件权限）
-node scripts/doctor.js        # 检查配置
-node scripts/doctor.js --fix  # 收紧权限（.env 与 CCM_DATA_DIR/*.json → 0600）
-
-npm start                     # http://localhost:3000
+node --version
+which claude
+npm install --omit=dev
+npm run setup
+node scripts/doctor.js
+npm start
 ```
 
-**更快：丢给你的编程 agent 代装**——在仓库目录里（或先让它 clone）把下面这段交给 Claude Code / Codex CLI 之类的编程 agent：
+`setup` 会生成 `AUTH_TOKEN`、询问允许 Claude 操作的 `WORK_DIR`，并明确询问是否安装 CLI hooks bridge。启动日志会打印带 token 的局域网地址，在手机上打开即可。
 
-```
-帮我首次安装并启动 claude-chat-mobile（把本机 claude CLI 接到手机的 web UI）。这是全新环境首次安装，
-不是重启已部署的常驻服务——CLAUDE.md 里「生产部署勿手动 npm start」那条对这次不适用。
-
-按顺序做，每步确认结果再进下一步：
-
-1. 前置校验：node --version 要 ≥ 20；which claude 要能找到且已登录（项目驱动的就是这个 CLI，
-   它不自带）。任一不满足就停下来告诉我，别自己装 claude。
-2. npm install --omit=dev
-3. 先跟我确认两件事再往下：
-   (a) WORK_DIR 挂哪个目录——给绝对路径。这是我在手机上能让 claude 读写的范围，别用我的整个家目录。
-   (b) 要不要装 CLI hooks 桥——装了以后我在电脑终端直接跑的 claude 会话也能推送到手机，
-       代价是会写我的全局 ~/.claude/settings.json。
-4. 用非交互模式写配置，不要跑交互向导（你的 shell 没有 TTY，向导会卡在提问上、静默什么都不做还退出 0）：
-   node scripts/setup.js --yes --work-dir=<第3步的绝对路径> --hooks=<on 或 off>
-5. node scripts/doctor.js 自检，按提示修（权限类问题可用 node scripts/doctor.js --fix）。
-6. 后台启动 server，别在前台跑（会一直阻塞你）。起来后用
-   curl -s "http://127.0.0.1:3000/health?token=<.env 里的 AUTH_TOKEN>"
-   拿到 JSON 才算启动成功，别只看进程在不在。
-7. 告诉我怎么在手机上打开：给我启动日志里那条带 token 的局域网地址。注意 AUTH_TOKEN 是密钥
-   （拿到它就等于拿到我这台机器的 shell），它存在 .env（权限 0600），别写进任何会外传的地方。
-8. 我手机第一次连进来会卡在设备指纹审批（光有 token 不够）。到时帮我跑 node scripts/device.js list，
-   确认是我的手机后 node scripts/device.js approve <ID>。
-
-如果我后续想要公网固定域名访问，参考 docs/deployment.md 帮我配。
-```
-
-Web 自己发起的会话开箱即用 SDK 状态栏，不需要改 Claude 配置。若还要在 Web **只读查看正在 CLI 里运行的会话**时同步 CLI 的模型、思考强度、上下文、成本和额度，可显式安装透明 statusline bridge：
+手机首次从非本机路径连接时，还要在电脑上批准设备：
 
 ```bash
-npm run statusline:status     # 只读查看，不改 ~/.claude
-npm run statusline:install    # 显式安装；不会由 npm install / npm start 自动执行
+node scripts/device.js list
+node scripts/device.js approve <ID>
 ```
 
-安装后重开 Claude CLI，并重启常驻 server；卸载用 `npm run statusline:uninstall`。
+完整的首次安装、非交互 setup、可复制的编程 agent 安装提示、PWA 和 bridge 配置见 [首次使用指南](docs/getting-started.md)。
 
-在电脑终端直接跑 `claude` 时，回合结束（Stop）与需要你介入（Notification）默认要等最长 2.5 秒轮询才被 Web 发现，也不会推送到手机。装上 CLI hooks 桥即可让 CLI 主动通知：
+## 运行方式
 
-```bash
-npm run hooks:status     # 只读查看，不改 ~/.claude
-npm run hooks:install    # 显式安装 + 自动回环验证，装完明确告诉你成没成
-npm run hooks:verify     # 随时重跑端到端验证
-npm run hooks:uninstall  # 只摘掉自己的 hook 条目，你已有的 hooks 一字不动
-```
-
-也可以在手机上开：**设置 → 服务状态 → 终端会话推送 → 开启**（确认后由 server 代跑安装器，同样只在你点击时才写配置）。首次跑 `npm run setup` 向导时也会问一次，默认装。
-
-装完**重开终端里的 claude 会话**才会加载 hooks。server 不在时 hook 只是静默落盘，绝不影响 CLI 本身；临时停用在 `.env` 设 `CLI_HOOKS_BRIDGE=off`，不必卸载。
-
-然后在手机上打开。启动日志会打印已带 token 的可用 URL：
-
-- **同一 WiFi：** 先在 `.env` 设 `AUTH_TOKEN`（局域网也必填，不设手机连不上），再打开启动时打印的局域网地址（`http://<lan-ip>:3000/#token=…`）。不需要隧道。
-- **公网 / 安装为 PWA**（PWA 需要 https）：在另一个终端跑隧道：
-
-```bash
-cloudflared tunnel --url http://localhost:3000
-# 手机打开 https://<random>.trycloudflare.com/#token=<你的 AUTH_TOKEN>
-# token 首次加载存入 localStorage，随后从地址栏清除
-```
-
-手机首次从非本机路径连入时，**光有 token 不够**：电脑上还要批一次设备指纹（TOFU）：
-
-```bash
-node scripts/device.js list           # 看待确认设备
-node scripts/device.js approve <ID>   # 批准后该设备立即解锁
-```
-
-> ⚠️ 不设 `AUTH_TOKEN` 时，服务只绑定 `127.0.0.1`。同 WiFi 的手机和隧道都连不上，这是有意为之。
->
-> 📌 上面是最简配置：临时随机隧道，只适合测试。固定域名、Cloudflare Access 双因素和后台常驻部署见 [docs/deployment.md](docs/deployment.md)。经 Cloudflare Access 验证的公网连接可跳过设备指纹这一步；临时 `cloudflared` 随机隧道**没有** Access，仍要走 `device.js approve`。
->
-> ⚠️ 这是一条可远程触达、直通你本机 shell 的代码执行通道。暴露到公网前，先读下面的[安全模型](#安全模型)。
-
-## 运行方式(三选一)
-
-按你的场景选一种。具体命令见上方[「快速开始」](#快速开始)与 [docs/deployment.md](docs/deployment.md):
-
-| 方式 | 适合 | 代价 |
+| 方式 | 适合 | 注意事项 |
 |---|---|---|
-| **同 WiFi 局域网直连**：`http://<lan-ip>:3000/#token=` | 在家、手机和电脑同一网络 | 出门用不了；无隧道，最省事 |
-| **临时公网**：`cloudflared tunnel --url`（随机域名） | 临时试用 / 演示 | 地址每次重启都变；官方标注仅测试用；仍要设备审批 |
-| **固定生产**：固定域名 + Cloudflare Access 2FA + 常驻进程 | 长期、随时随地用 | 一次性 DevOps 搭建，见 [docs/deployment.md](docs/deployment.md) |
+| 同 WiFi：`http://<lan-ip>:3000/#token=…` | 家中或办公室局域网 | 最省事，离开当前网络后不可用 |
+| 临时公网：`cloudflared tunnel --url http://localhost:3000` | 试用、演示 | 随机域名会变化；没有 Access，仍需设备审批 |
+| 固定生产：固定域名 + Cloudflare Access + 常驻服务 | 长期随时访问 | 需要一次性部署与运维，见 [部署指南](docs/deployment.md) |
+
+PWA 与 Web Push 需要 HTTPS；iOS Web Push 还要求 iOS 16.4+ 并先“添加到主屏幕”。
 
 ## 安全模型
 
-> **暴露到公网前务必先读。** 这是一条可远程触达、直通你本机 shell 的代码执行通道：
+> 这是一个可远程触达、直通本机 shell 的代码执行入口。暴露到公网前，请先理解这些边界。
 
-1. **每实例单用户。** 你运行自己的实例，给自己用。项目没有多用户、账号或登录系统；任何通过鉴权的请求，都和你本人坐在终端前拥有同样的权限。不要把它当多租户服务。
-2. **没有 token 就不出本机。** 未设置 `AUTH_TOKEN` 时，服务只绑定 `127.0.0.1`。不存在"留空 = 对全世界开放"的路径。要投送到公网，必须有 token。
-3. **自动放行集继承 CLI，不另造白名单。** 本项目不注入自己的 `allowedTools` / `disallowedTools`。自动放行 = 你已有 claude 配置里 `permissions.allow` 的合并结果：全局 `~/.claude/settings.json`、项目 `.claude/settings.json`、本地 `.claude/settings.local.json` 三处一并生效（经 `settingSources` 加载，与终端同源）。命中即放行；未命中就挂起，把审批请求推到手机——**App 内**可见完整命令与工作目录后再确认。
-   - Web 另有运行时权限档（含 `dontAsk` / `auto` / `bypassPermissions` 等）与审批 TTL 等行为，**不等于**「手机 UI 与交互式终端逐行为一致」；同源的是 settings 白名单来源，不是整套交互。
-   - ⚠️ **公网暴露前，审查你的全局 `~/.claude/settings.json` 白名单**。终端里多年累积的 `Bash(...)` / `Write` 等规则在这里也会自动放行，不会再弹手机。要收紧的不只项目那份配置。
-4. **设备信赖（TOFU）。** 既非本机、也未经 Cloudflare Access 验证的连接，必须先在电脑上一次性授权该设备才能操作。合法 token 本身不够。在电脑上执行：
-   ```bash
-   node scripts/device.js list
-   node scripts/device.js approve <ID>
-   ```
-   吊销用 `deny <ID>`。本机 loopback 连接与已通过 Cloudflare Access JWT 的公网连接会跳过这一步。
-5. **文件编辑器直写，不经审批链。** 项目文件浏览器里的「编辑」是你本人在手机上的显式操作，语义等同 `ssh` 进机器后用编辑器改文件——**不**经过 Claude 的 `canUseTool` 审批（那条链路管的是 agent 的自主行为，不是你自己点按钮）。仍有的防线：只能改**已存在**的文件（不会新建/删除）、大小上限 256KB、写前用内容哈希核对磁盘现状（与 Claude 并发改了同一文件会拒并提示冲突，不静默覆盖）、每次写回落审计日志。不想要这个能力就设 `FILE_EDIT=off`，整体退回只读浏览（前几版行为）。
+1. **单用户，权限等同机主。** 项目没有多用户或租户隔离；通过鉴权的操作拥有启动 `claude` 的本机账号权限。
+2. **无 token 不出本机。** 未设置 `AUTH_TOKEN` 时只监听 `127.0.0.1`；需要手机或隧道访问时必须设置强 token。
+3. **工作目录必须收窄。** `WORK_DIR` / `workdirs.json` 是文件、会话和 git 操作的范围门。不要为了省事把整个家目录交给远程入口。
+4. **自动放行继承 CLI 配置。** `~/.claude/settings.json`、项目 `.claude/settings.json` 和 `.claude/settings.local.json` 中的 `permissions.allow` 会同源生效；公网使用前应审查累积的 Bash/Write 等规则。
+5. **设备信任是第二道门。** 除本机直连或已通过 Cloudflare Access JWT 的连接外，合法 token 仍需一次性设备审批；可用 `node scripts/device.js deny <ID>` 吊销。
+6. **文件编辑器是用户直写。** 它不经过 Agent 的工具审批链，只允许修改已存在、≤256KB 的文件，并做范围校验、哈希冲突检测和审计记录；设 `FILE_EDIT=off` 可退回只读。
 
-## 成本提示
+漏洞请通过 [GitHub Security Advisories](SECURITY.md) 私下报告，不要公开提交 issue。
 
-**当前（截至 2026-07-20）：Agent SDK / `claude -p` 用量仍吃订阅额度，与交互式同池**。本项目走官方订阅路径时，不产生独立计费。
+## Web 与 CLI 如何协作
 
-背景：Anthropic 曾公告自 2026-06-15 起把 SDK *headless* 用量挪到独立 credit 池（Max 5x $100/月、按 API 价），但**该变更已于上线当天暂停、从未生效**（[官方 Help Center](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)）。Anthropic 称会重做方案并提前通知；现在是暂停，不是取消。
-
-- **潜在风险**：若政策复活，本项目的 SDK 用量会从订阅额度移出、可能撞独立 credit 上限。作者个人路径曾按 API 价粗算约 **~$716/月** 等效——**仅个人实测、非产品 SLA 或典型用户指标**；届时请用你自己的用量再预算。
-- **走第三方网关**（shell export 的 `ANTHROPIC_*`）：与此无关，按网关自己费率付费。
-
-## 特性
-
-在上面的核心循环之外：
-
-- **单驾驶员模型**：Web 与 CLI 轮流写同一会话；CLI 驾驶时 Web 只读镜像（transcript 追平），接管默认排队等本轮完结，避免并发写盘分叉。
-- **六种权限档**（default / plan / acceptEdits / dontAsk / auto / bypassPermissions），运行时可切；审批带 TTL 与完整性绑定。
-- **逐条消息切换模型**（支持网关后缀名）；resume 可回落展示会话末条模型。
-- **多 repo 与多会话**：白名单工作目录切换；首页枢纽 / 抽屉并发看多个会话。git worktree 若要用，把其绝对路径写入 `workdirs.json` 作为独立工作区（热加载，无需重启）。
-- **一轮一条**：任务运行中不接受新消息（输入框仍可打字存草稿，发送位变停止钮并常驻提示）；CLI 式动态状态行与回合收尾行。
-- **子 agent / 后台任务可见**，可停止后台任务；Task 清单工具流内渲染。
-- **文件与图片上传**（含剪贴板粘贴与发送前预览），带路径注入与穿越防护；历史附件可点预览；**项目文件浏览**（不越白名单工作目录，语法高亮）；小文件（≤256KB）可**直接在 CodeMirror 里编辑保存**——写前哈希比对防覆盖并发改动，`FILE_EDIT=off` 可整体关闭回到只读，见下方安全模型第 5 条；**composer `@` 文件引用**：候选来自授权目录内枚举，不接受任意路径拼接。
-- **工具卡片预览变更**：Edit / Write 看 diff、Read 看片段；base64 脱敏与 JSON 高亮。
-- **思考强度控制**、**单一来源状态栏**（Web 驾驶取 SDK；可选 bridge 让 CLI 驾驶取 CLI 快照），以及作为原生选择器的 **`AskUserQuestion`**。
-- **Web Push / ntfy 通知**：推送审批、提问与结果的**类型级**提示（不含命令/问题正文），点通知深链回会话（iOS 16.4+ 需先添加到主屏幕；可选配 ntfy 走自托管、锁屏更可靠）；socket 在线时结果类通知不重复推。Web Push 通道设置里可选**开启内容预览**（默认关；payload 本身已 RFC 8291 端到端加密，开启后带问题/工具/任务摘要），ntfy 不受此开关影响、恒最小化。
-- **会话两级删除**（产品移除 / SDK 真删底层文件）；「等我」跨会话聚合。
-- **PWA 可安装**：maskable 图标 + 独立显示，"添加到主屏幕"当 app 用。
-- **运维与安全加固**：日志脱敏、`0600` 原子写、`doctor` 启动自检、**UI 一键安全体检（脱敏，审查危险白名单）**、鉴权限速、可选 Cloudflare Access 2FA、`/metrics` 与服务状态面板。
-
-## 内部实现（想读代码 / fork 才看）
-
-内部是一层默认上锁的转发层：把你本机的 claude CLI（带着你的 CLAUDE.md/MCP/skills/登录态）接到手机浏览器。会话连续，过程可见，危险操作回手机审批。双通道并存：**Web 驾驶**走 SDK 流式；**CLI 驾驶**写磁盘 transcript，Web 只读追平。
-
-```mermaid
-graph LR
-    subgraph 手机
-        UI[public/ 单页<br/>聊天气泡·工具卡片·审批弹窗]
-    end
-    subgraph 公网
-        CF[Cloudflare Tunnel]
-    end
-    subgraph 本机
-        S[src/server/ + server.js 薄入口<br/>Express 静态 + Socket.IO 契约层<br/>鉴权 · 启动预检 · 设备信赖 · handler 兜底]
-        A[src/agent/agent.js · AgentSession<br/>长驻 SDK query · 权限闸门<br/>事件信封 seq+epoch · 环形缓冲]
-        J[(CCM_DATA_DIR/sessions.json<br/>会话元数据)]
-        H[catchUpTick<br/>只读镜像追平]
-        SDK[claude-agent-sdk]
-        CLI[本机 claude CLI<br/>完整加载你的配置]
-        T[(CLI transcript<br/>~/.claude/projects)]
-        FS[(你的项目文件<br/>WORK_DIR)]
-    end
-    UI <-->|"agent:event 信封 / user:* 事件<br/>(事件契约, WebSocket)"| CF <--> S
-    S <--> A
-    A <-->|streaming input<br/>Web 驾驶| SDK <-->|spawn| CLI
-    CLI --> FS
-    CLI -->|CLI 驾驶直写| T
-    T -->|轮询追平| H --> S
-    S --- J
+```text
+Web 驾驶：手机 → Socket.io → AgentSession → Agent SDK → 本机 claude CLI → 工作区
+CLI 驾驶：终端 claude → transcript / hooks → server → 手机只读镜像
 ```
 
-### 消息流程
+两条路径共享 CLI 的落盘会话记录，但不共享一个实时 TTY。CLI 驾驶时，Web 只能看到已经落盘的内容；hooks 负责加速“回合结束/需要你”信号，不会把终端进程变成可双向附着的会话。Web 接管前会等待终端回合结束，并在发送前吸收磁盘上的外部增长。
 
-**Web 驾驶（手机发消息）：**
+完整组件图、消息流、单驾驶员状态转换与断线回放见 [架构说明](docs/architecture.md)。
 
-1. 手机 `user:message {text}` → server 校验 → 路由到目标实例 `agents.get(instanceId)`（懒重生 resume；`session:new` 后首条消息才懒开 FRESH 实例）
-2. 若磁盘相对 SDK 内存有外部增长（CLI 写过），先 dispose+resume 吸收，再发送——防上下文分叉
-3. 文本 push 进 AgentSession 的 streaming input → SDK → claude CLI 在 `WORK_DIR` 干活
-4. SDK 消息流回 `map()`：流式文本→`text_delta`、工具调用→`tool_use`/`tool_result`、白名单外操作→`permission_request`（挂起等手机点允许/拒绝）
-5. 每个事件套上 `{seq, epoch, sessionId, instanceId, cwd, ts, type, payload}` 信封 → 进 2000 条环形缓冲 → `io.to('approved').emit` 广播给已过审设备（前端按 `viewingInstanceId` 分流；后台会话的高频 delta 不广播以省带宽）
-6. 手机断线再连：`sync:since {sessionId, lastSeq, instanceId}` 补发缓冲；`epoch` 变化 = 服务端换了实例，客户端自动重置去重基线
+## 文档导航
 
-**CLI 驾驶（终端直开，Web 只读）：**
+- [首次使用指南](docs/getting-started.md)：从 clone 到手机发出第一条消息。
+- [部署与运维](docs/deployment.md)：Cloudflare Tunnel、Access、LaunchAgent 与 systemd。
+- [架构说明](docs/architecture.md)：Web/CLI 双通道、事件信封与接管边界。
+- [展示契约](docs/display-contracts.md)：模型、思考强度和状态栏的事实源。
+- [仓库地图](docs/repository-map.md)：入口、目录职责与完整文件清单。
+- [环境变量模板](.env.example)：所有运行时配置及默认值。
+- [安全策略](SECURITY.md)：漏洞报告方式。
 
-1. 你在电脑终端里对 `claude` 打字；CLI **不**经过本项目的 Agent SDK 子进程
-2. 输出写入 `~/.claude/projects/` 下 transcript
-3. server 的 `catchUpTick` 轮询磁盘，把新落定消息以只读镜像推到已打开该会话的 Web 客户端
-4. 镜像锁定期间 Web 输入受限（发送钮变为续接/说明态）；终端静默一段时间后自动解锁，Web 可接管
+## 用量与兼容性
 
-运行时依赖：`@anthropic-ai/claude-agent-sdk`、`express`、`compression`、`socket.io`、`dotenv`、`web-push`、`jose`。前端第三方库本地自托管到 `public/vendor/`（Tailwind/marked/highlight.js/DOMPurify），不依赖 CDN；见 [public/vendor/THIRD-PARTY-NOTICES.md](public/vendor/THIRD-PARTY-NOTICES.md)。
+截至 **2026-07-31**，Agent SDK、`claude -p` 和第三方 Agent SDK 应用仍使用 Claude 订阅额度；Anthropic 曾公布的独立 credit 方案处于暂停状态。政策可能变化，请以 [官方说明](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) 为准。
+
+使用 API key 或第三方网关时，费用与限额由对应平台决定。项目记录的 claude CLI 版本只是发布验证环境；升级前可查看 [Releases](https://github.com/Ike-li/claude-chat-mobile/releases)。
 
 ## 许可证
 
 [GNU AGPL-3.0-only](LICENSE) © 2026 Ike-li，附带 Section 7 补充条款；见 [NOTICE](NOTICE)。
 
-简单说：你可以自由使用、研究、修改并自托管本软件。但如果你把修改后的版本作为网络服务对外提供，AGPL 要求你同样以 AGPL 开源你的源代码；补充条款还要求你保留原作者署名、不得歪曲项目来源。若有无法满足上述条件的使用需求，请开 issue 沟通。
+你可以使用、研究、修改并自托管本软件。若把修改后的版本作为网络服务对外提供，AGPL 要求开放对应源代码；补充条款还要求保留原作者署名、不得歪曲项目来源。
 
 ## 友链
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -1,0 +1,162 @@
+# Architecture
+
+> This document explains how Claude Chat Mobile lets Web and terminal CLI use the same configuration and persisted sessions without pretending they share a live TTY.
+
+[中文](architecture.md) · [Back to README](../README.en.md)
+
+## Design goals
+
+Claude Chat Mobile is a local forwarding and synchronization service:
+
+- For Web-originated work, it drives the local `claude` CLI through the Claude Agent SDK.
+- For terminal-originated work, it does not take over the terminal process; it reads the CLI transcript after content reaches disk.
+- Both sides share project configuration, tools, permission sources, and session history, but only one side may drive writes at a time.
+- When the phone disconnects or moves to the background, reconnect can deduplicate and replay events still retained by the server.
+
+It is not remote desktop software, a TTY multiplexer, or a multi-tenant hosted service, and it never exposes the terminal process's stdin/stdout to the browser.
+
+## Components
+
+```mermaid
+graph LR
+    subgraph Phone["Phone / PWA"]
+        UI["public/ single-page app<br/>messages · tools · approvals · files"]
+    end
+    subgraph Edge["Optional public edge"]
+        CF["Cloudflare Tunnel + Access"]
+    end
+    subgraph Host["Local computer"]
+        S["server.js + src/server/<br/>Express · Socket.io · auth · routing"]
+        A["AgentSession<br/>SDK stream · permission gate · event buffer"]
+        SDK["Claude Agent SDK"]
+        CLI["Local claude CLI"]
+        T[("~/.claude/projects/<br/>transcript")]
+        H["catchUpTick + hooks inbox<br/>read-only catch-up and fast signals"]
+        D[("CCM_DATA_DIR<br/>devices · pointers · approvals · audit")]
+        FS[("Approved workspaces")]
+    end
+
+    UI <-->|"agent:event / user:*"| CF <--> S
+    S <--> A
+    A <-->|"Web driver"| SDK <-->|spawn| CLI
+    CLI <--> FS
+    CLI -->|"terminal driver persists"| T
+    T --> H --> S
+    S --- D
+```
+
+Cloudflare is optional. The phone can connect directly on the same Wi-Fi; only a fixed public deployment needs Tunnel/Access or an equivalent secure edge.
+
+## Two data paths
+
+### Web driver
+
+1. The browser opens a Socket.io connection, authenticates with `AUTH_TOKEN` or Cloudflare Access, and passes the device gate.
+2. `user:*` events enter the server and route by `instanceId` / current view to the matching `AgentSession`.
+3. `AgentSession` writes into Agent SDK streaming input. The SDK starts or resumes the local CLI inside an approved `cwd`.
+4. The mapping layer turns SDK output into product events for text, tools, approvals, questions, status, and background tasks.
+5. Every outbound event uses the `agent:event` envelope; the front end routes it by session and instance before rendering.
+
+A Web session is not a remote Anthropic chat page. The SDK child inherits the local CLI login, project `CLAUDE.md`, Claude settings, MCP servers, skills, hooks, and a controlled provider environment.
+
+### CLI driver
+
+1. The user runs `claude` directly in a computer terminal. This process does not pass through Claude Chat Mobile's SDK child.
+2. The CLI writes completed messages to a transcript under `~/.claude/projects/`.
+3. The server's `catchUpTick` checks the current session for disk growth every 2.5 seconds by default and sends newly persisted messages to Web.
+4. The optional hooks bridge writes Stop / Notification to a file inbox. `fs.watch` only accelerates a check; the disk transcript remains the source of truth.
+5. The optional statusline bridge writes snapshots of CLI model, effort, context, cost, and quota.
+
+The read-only mirror therefore has strict limits:
+
+- It sees content after it reaches disk, not live stdout.
+- It cannot write to or attach to the terminal process's stdin.
+- Thinking, subagent intermediate work, or tool output may remain invisible until persisted.
+- Hooks shorten discovery of “turn ended / needs you,” but they do not turn the mirror into a shared TTY.
+
+## Single-driver model
+
+Sharing a transcript does not make concurrent writes safe. Two independent Claude turns can fork context, race on files, and produce incorrect completion state.
+
+The project reduces that risk with these rules:
+
+1. **While Web drives**, its `AgentSession` is the writer. The front end enforces one message per turn and changes Send to Stop while work is active.
+2. **When external CLI growth is detected**, the server marks disk as newer than SDK memory and puts Web into read-only mirror mode.
+3. **While the CLI is still active**, Web does not send another message to that session and shows terminal-driver state.
+4. **After the terminal turn ends and passes the quiet-period check**, the mirror lock is released and Web may resume.
+5. **Before a Web takeover send**, if the transcript has grown beyond the current SDK instance, the server disposes that stale instance and resumes from disk before sending.
+
+Polling leaves an observation window of up to one check interval. Session switches, manual mirror refresh, and hook signals can schedule an earlier check, but none of them proves control over another live process.
+
+## Event envelope and reconnect replay
+
+Outbound Socket.io traffic uses one `agent:event` envelope:
+
+```json
+{
+  "seq": 42,
+  "epoch": "server-instance-id",
+  "sessionId": "cli-session-id",
+  "instanceId": "web-instance-id",
+  "cwd": "/approved/workspace",
+  "ts": 1780000000000,
+  "type": "text_delta",
+  "payload": {}
+}
+```
+
+- `type` comes from a closed event set. `scripts/contract-check.js` checks consistency across backend senders, front-end receivers, and the mock server.
+- `seq` increases within one `AgentSession` and lets the front end deduplicate.
+- `epoch` identifies a server/instance generation; a change resets the client's old deduplication baseline.
+- `sessionId` and `instanceId` remain separate so persisted CLI-session identity is not confused with a current Web process.
+- Each AgentSession keeps a bounded ring buffer. A client requests a retained gap with `sync:since`.
+
+The ring buffer is not permanent history. If a gap has fallen out of the buffer or the service restarted, the client falls back to authenticated `session:history` and rebuilds stable messages from the CLI transcript. High-frequency transient state is not all persisted.
+
+## Authentication and scope boundaries
+
+```text
+HTTP / Socket authentication
+            ↓
+device trust or Cloudflare Access
+            ↓
+WORK_DIR / workdirs.json scope gate
+            ↓
+CLI permissions.allow + current Web permission mode
+            ↓
+Agent tool approval or direct user file edit
+```
+
+These boundaries do not replace each other:
+
+- `AUTH_TOKEN` proves possession of the instance secret; it does not prove that a device was approved.
+- Cloudflare Access adds public-edge identity; it does not expand workspace scope.
+- `WORK_DIR` / `workdirs.json` constrain paths; they do not decide which Claude tools run automatically.
+- Agent `canUseTool` approvals govern autonomous Agent actions. Clicking Save in the file editor is a direct user write with separate scope, size, content-hash, and audit controls.
+
+See the [README security model](../README.en.md#security-model) for the concise boundary list and [deployment and operations](deployment.md) for network topology.
+
+## State and persistence
+
+| Data | Source of truth | Purpose |
+|---|---|---|
+| Claude conversations | `~/.claude/projects/` transcript | CLI/Web resume and stable history |
+| Web instance runtime | In-memory `AgentSession` | Streaming turns, approvals, event buffer |
+| CCM control plane | `CCM_DATA_DIR` | Session pointers, devices, approvals, audit, push, and caches |
+| Workspace allowlist | `WORK_DIR` / `WORK_DIRS_FILE` | Limits visible and operable directories |
+| Web-driver status line | SDK events | Current model, context, cost, and effort |
+| CLI-driver status line | Optional statusline snapshots | Read-only terminal-session status |
+| Immediate CLI signals | Optional hooks inbox | Faster Stop / Notification handling |
+
+`CCM_DATA_DIR` does not store the original Claude transcript. Clearing it affects CCM control-plane state but is not the same operation as deleting every Claude session; SDK-level session deletion is a separate explicit action.
+
+## Code entrypoints
+
+- `server.js`: compatibility launcher; assembly lives in `src/server/app.js`.
+- `src/agent/agent.js`: `AgentSession`, SDK mapping, permission gate, and ring buffer.
+- `src/sessions/history.js`: transcript reading, catch-up, and mirror decisions.
+- `src/ops/cli-hooks-bridge.js` / `src/ops/cli-statusline-bridge.js`: CLI signal and snapshot consumers.
+- `public/js/app.js` and `public/js/app/`: client state, event dispatch, and interaction modules.
+- `scripts/contract-check.js`: bidirectional Socket.io event-contract gate.
+
+See the [repository map](repository-map.md) for complete directory ownership and file inventory, and the [display contracts](display-contracts.md) (Chinese) for cross-layer model, effort, and statusline transformations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,162 @@
+# 架构说明
+
+> 本文解释 Claude Chat Mobile 如何在“不共享实时 TTY”的前提下，让 Web 与终端 CLI 续用同一套配置和落盘会话。
+
+[English](architecture.en.md) · [返回 README](../README.md)
+
+## 设计目标
+
+Claude Chat Mobile 是一层本机转发与同步服务：
+
+- Web 发起任务时，通过 Claude Agent SDK 驱动本机 `claude` CLI。
+- 终端直接运行任务时，不接管终端进程，只读取 CLI 已落盘的 transcript。
+- 两端共享项目配置、工具、权限来源和会话记录，但同一时刻只允许一个驾驶员写入。
+- 手机断线或切后台后，重新连接时可以去重并补发服务端仍保留的事件。
+
+它不是远程桌面、TTY multiplexor、多租户托管服务，也不会把终端进程的 stdin/stdout 暴露给浏览器。
+
+## 总体组件
+
+```mermaid
+graph LR
+    subgraph Phone["手机 / PWA"]
+        UI["public/ 单页应用<br/>消息·工具卡片·审批·文件"]
+    end
+    subgraph Edge["可选公网入口"]
+        CF["Cloudflare Tunnel + Access"]
+    end
+    subgraph Host["本机"]
+        S["server.js + src/server/<br/>Express · Socket.io · 鉴权 · 路由"]
+        A["AgentSession<br/>SDK 流 · 权限闸门 · 事件缓冲"]
+        SDK["Claude Agent SDK"]
+        CLI["本机 claude CLI"]
+        T[("~/.claude/projects/<br/>transcript")]
+        H["catchUpTick + hooks inbox<br/>只读追平与即时信号"]
+        D[("CCM_DATA_DIR<br/>设备·会话指针·审批·审计")]
+        FS[("授权工作区")]
+    end
+
+    UI <-->|"agent:event / user:*"| CF <--> S
+    S <--> A
+    A <-->|"Web 驾驶"| SDK <-->|spawn| CLI
+    CLI <--> FS
+    CLI -->|"CLI 驾驶时落盘"| T
+    T --> H --> S
+    S --- D
+```
+
+Cloudflare 不是必需组件。同一 WiFi 可直接访问本机 server；固定公网部署才需要 Tunnel/Access 或等价的安全入口。
+
+## 两条数据路径
+
+### Web 驾驶
+
+1. 浏览器建立 Socket.io 连接，通过 `AUTH_TOKEN` 或 Cloudflare Access 完成鉴权，再通过设备门。
+2. 用户事件以 `user:*` 进入 server，并按 `instanceId` / 当前视图路由到对应 `AgentSession`。
+3. `AgentSession` 把消息送入 Agent SDK streaming input；SDK 启动或续接本机 CLI，让它在授权 `cwd` 中工作。
+4. SDK 输出经映射层转成文本、工具、审批、提问、状态、后台任务等产品事件。
+5. 所有出向事件统一封装为 `agent:event`，前端按会话与实例分流并渲染。
+
+Web 会话并不是远端 Anthropic 聊天页。SDK 子进程继承本机 CLI 的登录态、项目 `CLAUDE.md`、Claude settings、MCP、skills、hooks 和受控 provider 环境。
+
+### CLI 驾驶
+
+1. 用户在电脑终端直接运行 `claude`。这个进程不经过 Claude Chat Mobile 的 Agent SDK 子进程。
+2. CLI 把已经完成的消息写入 `~/.claude/projects/` 下的 transcript。
+3. server 的 `catchUpTick` 默认每 2.5 秒检查当前会话的磁盘变化，并把新增的落盘消息推给 Web。
+4. 可选 hooks bridge 把 Stop / Notification 写入文件投递箱；`fs.watch` 只是加速触发器，磁盘 transcript 仍是真相源。
+5. 可选 statusline bridge 给 CLI 会话写入模型、effort、上下文、成本和额度快照。
+
+因此只读镜像有明确限制：
+
+- 只能看到已经落盘的内容，不是实时 stdout。
+- 不能向终端进程输入，也不能附着到它的 stdin。
+- 尚未落盘的 thinking、子 agent 中间过程或工具输出可能暂时不可见。
+- hooks 可以缩短“回合结束/需要你”的发现时间，但不会把镜像变成共享 TTY。
+
+## 单驾驶员模型
+
+共享 transcript 不等于允许两端同时写。并发启动两个独立 Claude turn 可能造成上下文分叉、文件竞争和错误的结束状态。
+
+项目用以下规则降低风险：
+
+1. **Web 驾驶时**，该 `AgentSession` 是写入方，前端执行“一轮一条”并在任务中把发送键改为停止键。
+2. **检测到 CLI 外部写入时**，server 标记磁盘状态比 SDK 内存更新，Web 进入只读镜像。
+3. **CLI 仍在运行时**，Web 不向同一会话发送新消息；界面展示终端驾驶状态。
+4. **终端回合结束并经过静默判定后**，镜像锁释放，Web 才能续接。
+5. **Web 接管发送前**，若 transcript 相对现有 SDK 实例有外部增长，server 先 dispose 旧实例并 resume 吸收，再发送新消息。
+
+轮询意味着存在最多一个检查周期的观察窗口。切换会话、手动刷新镜像与 hooks 信号会主动插队触发检查，但它们仍不能证明对另一个活进程拥有控制权。
+
+## 事件信封与断线回放
+
+出向 Socket.io 只使用一个 `agent:event` 信封：
+
+```json
+{
+  "seq": 42,
+  "epoch": "server-instance-id",
+  "sessionId": "cli-session-id",
+  "instanceId": "web-instance-id",
+  "cwd": "/approved/workspace",
+  "ts": 1780000000000,
+  "type": "text_delta",
+  "payload": {}
+}
+```
+
+- `type` 是闭合事件集合，由 `scripts/contract-check.js` 对后端发送方、前端接收方与 mock server 做一致性校验。
+- `seq` 在一个 `AgentSession` 内递增，前端据此去重。
+- `epoch` 标识服务端/实例世代；变化时客户端重置旧的去重基线。
+- `sessionId` 与 `instanceId` 分开，避免同一 CLI 会话的逻辑身份和当前 Web 进程实例混淆。
+- 每个 AgentSession 保留有界环形缓冲；客户端以 `sync:since` 请求仍在缓冲中的缺口。
+
+环形缓冲不是永久历史。缺口超出缓冲或服务重启时，客户端回退到鉴权的 `session:history`，从 CLI transcript 重建稳定消息。高频瞬态状态不会全部进入永久历史。
+
+## 鉴权与范围边界
+
+```text
+HTTP / Socket 鉴权
+        ↓
+设备信任或 Cloudflare Access
+        ↓
+WORK_DIR / workdirs.json 范围门
+        ↓
+CLI permissions.allow + Web 当前权限档
+        ↓
+Agent 工具审批或用户直接文件编辑
+```
+
+这些边界互不替代：
+
+- `AUTH_TOKEN` 证明请求持有实例密钥，不代表设备已经获准。
+- Cloudflare Access 是公网身份层，不扩大工作区。
+- `WORK_DIR` / `workdirs.json` 限定路径，不决定 Claude 工具是否自动获批。
+- Agent 的 `canUseTool` 审批只管理 Agent 自主行为；用户在文件编辑器中点击保存属于直接写入，走独立的范围、大小、哈希与审计防线。
+
+安全摘要见 [README 安全模型](../README.md#安全模型)，部署拓扑见[部署与运维](deployment.md)。
+
+## 状态与持久化
+
+| 数据 | 事实源 | 用途 |
+|---|---|---|
+| Claude 对话 | `~/.claude/projects/` transcript | CLI/Web 续接与稳定历史 |
+| Web 实例运行态 | 内存中的 `AgentSession` | 流式 turn、审批、事件缓冲 |
+| CCM 控制面 | `CCM_DATA_DIR` | 会话指针、设备、审批、审计、推送与缓存 |
+| 工作区白名单 | `WORK_DIR` / `WORK_DIRS_FILE` | 限定可见与可操作目录 |
+| Web 驾驶状态栏 | SDK 事件 | 当前模型、上下文、成本、effort |
+| CLI 驾驶状态栏 | 可选 statusline 快照 | 终端会话的只读状态展示 |
+| CLI 即时信号 | 可选 hooks 投递箱 | Stop / Notification 加速与通知 |
+
+`CCM_DATA_DIR` 不保存 Claude 原始 transcript。清理它会影响 CCM 的控制面状态，但不会等同删除全部 Claude 会话；SDK 真删会话是另一条显式操作。
+
+## 代码入口
+
+- `server.js`：兼容启动入口；实际装配在 `src/server/app.js`。
+- `src/agent/agent.js`：`AgentSession`、SDK 映射、权限闸门与环形缓冲。
+- `src/sessions/history.js`：transcript 读取、追平与镜像判定。
+- `src/ops/cli-hooks-bridge.js` / `src/ops/cli-statusline-bridge.js`：CLI 侧信号与快照消费。
+- `public/js/app.js` 与 `public/js/app/`：客户端状态、事件派发与交互模块。
+- `scripts/contract-check.js`：双向 Socket.io 事件契约门禁。
+
+完整目录职责与文件清单见[仓库地图](repository-map.md)；模型、effort 与 statusline 的跨层变换见[展示契约](display-contracts.md)。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,6 +4,8 @@
 >
 > 下文用占位符 `<your-domain>`、`<your-team>`、`<UUID>` 等，替换为你自己的值。Linux/systemd 用户把 LaunchAgent 部分换成 systemd unit，思路一致。
 
+首次本地安装先看[首次使用指南](getting-started.md)；Web/CLI 双通道与单驾驶员边界见[架构说明](architecture.md)。
+
 ## 架构
 
 ```
@@ -15,7 +17,7 @@
   - server：`node server.js`，**经登录 shell（`zsh -lc` / `bash -lc`）启动**，保证 claude 的 PATH / 登录态与你终端一致。
   - tunnel：`cloudflared` 命名隧道，把 `:3000` 投到公网域名。
 - **鉴权分层**：公网走 Access JWT（服务端 `src/auth/cf-access.js` fail-closed 校验）；局域网/本机 `http://<lan-ip>:3000/#token=…` 仍走 `AUTH_TOKEN`。
-  > ⚠️ **反代拓扑会静默关掉设备审批层**。设备指纹审批按 socket 直连 peer 的 IP 判定「本机」。本配方里 Cloudflare 隧道在 `localhost:3000` 落地，连接显成 `127.0.0.1`，但公网路径已由 Access JWT 兜底，所以可接受。**若你换成任何在本机落地的其他反代**（nginx/Caddy 的 `proxy_pass localhost`、SSH 端口转发、frp 等），所有客户端都会显成本机，设备审批层会被跳过，**防线只剩 `AUTH_TOKEN`**。这类拓扑下务必设强 `AUTH_TOKEN`，不要指望设备审批纵深。
+  > 设备审批不会只凭 socket peer 是 loopback 就跳过：server 还会检查 Host。公网 Host（含 cloudflared/nginx/SSH 反代到 `127.0.0.1`）仍需设备 token；只有真实本机 Host，或已经通过 Cloudflare Access JWT 的连接，才跳过这层。
 
 ## ⚠️ 最容易忘的一点
 

--- a/docs/display-contracts.md
+++ b/docs/display-contracts.md
@@ -4,6 +4,8 @@
 > **可执行锚点**：`tests/unit/display-contracts.test.mjs`（改契约先改测试，再改实现）。  
 > **范围（v1）**：模型 · 思考强度 effort · statusline。其它面（工具卡/历史/权限 pill）见文末扩展清单。
 
+项目入口见 [README](../README.md)；首次运行见[首次使用指南](getting-started.md)；整体数据路径见[架构说明](architecture.md)。
+
 **原则**
 
 1. **不是 100% 字节透传**。每条契约写明「源 → 允许变换 → 屏幕上应是什么」。

--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -1,0 +1,275 @@
+# Getting Started
+
+> Goal: start with a computer where `claude` already works, run Claude Chat Mobile, and send the first message from your phone.
+
+[中文](getting-started.md) · [Back to README](../README.en.md)
+
+## What you will have
+
+- A Claude Chat Mobile server running only on your computer.
+- A phone entrypoint protected by `AUTH_TOKEN`, a workspace allowlist, and device approval.
+- A Web UI that shares configuration, tools, and persisted session history with your local `claude` CLI.
+
+This guide covers a first installation. If LaunchAgent or systemd already keeps the app running, do not start a second copy with `npm start`; restart it through the [deployment guide](deployment.md) instead.
+
+## 1. Check the prerequisites
+
+```bash
+node --version
+which claude
+claude --version
+```
+
+You need:
+
+- Node.js 20 or newer.
+- A local `claude` command that `which` can find.
+- An authenticated CLI that can start a normal terminal conversation.
+- macOS or Linux. Native Windows is experimental; WSL2 is recommended.
+
+The project does not bundle, install, or sign in to Claude for you.
+
+### Claude subscriptions and third-party gateways
+
+- Claude subscription: make sure the local account that will start the server is already signed in to `claude`; no extra API key is needed.
+- Third-party gateway: export the required `ANTHROPIC_*` values in the **shell that will start the server**, then start the project.
+- Do not put `ANTHROPIC_*` in the project's `.env`. Startup strips those values so a project file cannot override the CLI/provider environment.
+
+## 2. Get the code and install dependencies
+
+```bash
+git clone https://github.com/Ike-li/claude-chat-mobile.git
+cd claude-chat-mobile
+npm install --omit=dev
+```
+
+`--omit=dev` installs only runtime dependencies and does not download Playwright browsers. Use a full `npm install` when you need to develop or run tests.
+
+## 3. Create local configuration
+
+### Interactive wizard
+
+Run this in a real terminal:
+
+```bash
+npm run setup
+```
+
+The wizard:
+
+1. Creates a random `AUTH_TOKEN`, writes it to `.env`, and sets mode `0600`.
+2. Asks for `WORK_DIR`. Choose a specific project directory instead of exposing your whole home directory for convenience.
+3. Asks whether to install the CLI hooks bridge. Installation is the default, but it writes `~/.claude/settings.json` only after you confirm.
+
+If `.env` already exists, the wizard does not overwrite it by default.
+
+### Non-interactive mode
+
+A coding agent, CI shell, or any environment without a TTY must be explicit:
+
+```bash
+node scripts/setup.js \
+  --yes \
+  --work-dir=/absolute/path/to/project \
+  --hooks=off
+```
+
+- `--work-dir` is required and never silently falls back to `$HOME`.
+- `--hooks` accepts only `on` or `off`; `on` changes user-level Claude hooks configuration.
+- If `.env` exists, the command refuses to overwrite it. Add `--force` only after deciding to replace its current token and configuration.
+- Use `--env <path>` to target another environment file.
+
+For multiple workspaces, set `WORK_DIRS_FILE=workdirs.json` in `.env` and use an array of absolute paths:
+
+```json
+[
+  "/Users/you/code/project-a",
+  {
+    "path": "/Users/you/code/project-b",
+    "sessionLimit": 10
+  }
+]
+```
+
+`workdirs.json` hot-reloads. A git worktree must also be listed as its own absolute path; the project never discovers or authorizes it implicitly.
+
+## 4. Run the preflight checks
+
+```bash
+node scripts/doctor.js
+```
+
+The doctor checks the token, CLI path, workspaces, port, gateway environment, file permissions, bridge state, and documentation/front-end consistency.
+
+For permission-only repairs:
+
+```bash
+node scripts/doctor.js --fix
+```
+
+`--fix` tightens permissions on `.env` and control-plane JSON files. Read the diagnosis before deciding to use it.
+
+## 5. Start the server
+
+For a first local trial:
+
+```bash
+npm start
+```
+
+The default port is `3000`. The startup log should show:
+
+- that the server is listening;
+- a redacted token status;
+- a LAN URL that can be opened on your phone;
+- bridge and pending-device status.
+
+When `AUTH_TOKEN` is set, the health endpoint also requires authentication:
+
+```bash
+curl -sS "http://127.0.0.1:3000/health?token=<AUTH_TOKEN>"
+```
+
+The server is ready when it returns JSON containing `status`, `versions`, `buildNonce`, and `timestamp`. Treat `AUTH_TOKEN` as a key to your local shell: never paste the real value into issues, chat logs, or screenshots.
+
+If LaunchAgent or systemd already runs this checkout, port 3000 is probably occupied. Do not start a second server; use the [operations quick reference](deployment.md#运维速查) to restart the existing service.
+
+## 6. Open it on your phone
+
+### Same Wi-Fi
+
+Open the address printed at startup:
+
+```text
+http://<lan-ip>:3000/#token=<AUTH_TOKEN>
+```
+
+After the first load, the browser stores the token in `localStorage` and removes it from the address bar.
+
+### Temporary HTTPS
+
+PWA installation and Web Push require HTTPS. For a temporary trial, run this in another terminal:
+
+```bash
+cloudflared tunnel --url http://localhost:3000
+```
+
+Then open:
+
+```text
+https://<random>.trycloudflare.com/#token=<AUTH_TOKEN>
+```
+
+A quick tunnel is for testing: its hostname may change on every start and it has no Cloudflare Access layer, so device approval still applies. For a fixed domain, Access 2FA, and a persistent service, use the [deployment guide](deployment.md).
+
+## 7. Approve the phone
+
+The first non-local connection waits for device approval. On the computer, run:
+
+```bash
+node scripts/device.js list
+node scripts/device.js approve <ID>
+```
+
+Check the pending device ID before approving it. The page unlocks immediately afterward; the token does not need to be entered again.
+
+To revoke a mistaken approval or a lost device:
+
+```bash
+node scripts/device.js deny <ID>
+```
+
+Local loopback connections and requests already validated by Cloudflare Access JWT skip device approval. Normal LAN access and temporary quick tunnels do not.
+
+## 8. Complete the first-run check
+
+On the phone, verify:
+
+1. The expected workspace appears on the home screen.
+2. A new session can send a harmless prompt such as “Reply with OK only.”
+3. The response streams and reaches a finished-turn state.
+4. Settings show model, permission mode, effort, and service status.
+5. If Web Push is enabled, use “Send a test push” now instead of discovering a broken path during a real approval.
+
+The minimum path is now complete. Both bridges below are optional enhancements and are not required for Web-originated sessions.
+
+## Optional: CLI statusline bridge
+
+Web-driven sessions have an SDK status line out of the box. Install this bridge only if you also want a **read-only view of a terminal-driven session** to show the CLI model, effort, context, cost, and quota.
+
+```bash
+npm run statusline:status
+npm run statusline:install
+```
+
+- `status` is read-only and does not modify `~/.claude`.
+- `install` is explicit opt-in and wraps an existing Claude CLI statusline command. The installer refuses when no statusline is configured.
+- Reopen the terminal Claude CLI and restart the persistent server after installation.
+- `npm run statusline:uninstall` restores the original command from its manifest and refuses to overwrite drifted configuration.
+
+## Optional: CLI hooks bridge
+
+Without hooks, the server still polls the transcript every 2.5 seconds, but terminal Stop / Notification events cannot proactively wake the phone. With the bridge, the CLI writes those events to a private file inbox that the server consumes immediately and routes through notification settings.
+
+```bash
+npm run hooks:status
+npm run hooks:install
+npm run hooks:verify
+npm run hooks:uninstall
+```
+
+- `status` is read-only.
+- `install` appends only its own hook entries, preserves existing hooks, and performs a loopback verification.
+- Open a new terminal Claude CLI session after installation; an existing process does not reload hooks.
+- If the server is offline, the hook writes its file and exits quietly without blocking the CLI.
+- Set `CLI_HOOKS_BRIDGE=off` in `.env` to pause server consumption without removing global configuration.
+
+The phone UI can also install or remove the bridge explicitly under Settings → Service status → Terminal session notifications.
+
+<details>
+<summary>Delegate first installation to a coding agent</summary>
+
+Give the following prompt to Claude Code, Codex CLI, or another local coding agent from the repository directory:
+
+```text
+Install and start claude-chat-mobile for the first time. It connects my local claude CLI to a phone Web UI.
+This is a clean first installation, not a restart of an already deployed persistent service.
+
+Follow these steps in order and verify each result before continuing:
+1. Check that node --version is at least 20, which claude finds the command, and claude is authenticated.
+   Stop and tell me if any check fails; do not install or sign in to claude yourself.
+2. Run npm install --omit=dev.
+3. Ask me for the absolute WORK_DIR and whether to install the CLI hooks bridge.
+   Do not use my whole home directory. hooks=on changes ~/.claude/settings.json.
+4. Your shell has no TTY, so do not run the interactive wizard. Use:
+   node scripts/setup.js --yes --work-dir=<confirmed absolute path> --hooks=<on or off>
+   If .env already exists, stop instead of adding --force yourself.
+5. Run node scripts/doctor.js. Use --fix only when its output calls for a safe permission repair.
+6. Confirm no persistent service owns the port, then start the server in the background. Verify authenticated
+   /health JSON; do not rely only on the process existing.
+7. Give me the LAN phone URL from startup logs, but never write AUTH_TOKEN into any file or report that may leave
+   this machine.
+8. After my phone connects, run node scripts/device.js list. Let me verify the device before running approve.
+Use docs/deployment.md for a fixed public domain or persistent service. Do not change system services on your own.
+```
+
+</details>
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| No phone URL in startup logs | `AUTH_TOKEN` is unset; rerun setup or correct `.env`, then restart |
+| An agent ran setup but wrote nothing | Interactive mode was used without a TTY; use `--yes --work-dir=... --hooks=...` |
+| `EADDRINUSE :3000` | A persistent service or another process owns the port; do not blindly start another |
+| The phone stays on device approval | Run `device.js list`, verify the ID, and approve the correct device |
+| A third-party gateway is ignored | `ANTHROPIC_*` must come from the server's startup shell, not `.env` |
+| CLI session status or notifications are missing | Check the statusline and hooks bridges separately; they solve different problems |
+| Android installs only a browser shortcut | Cloudflare Access may block PWA icons; see the [deployment guide](deployment.md#2b-android-pwa图标必须对匿名可达) |
+
+## Next steps
+
+- Long-term public access: [Deployment and operations](deployment.md) (Chinese)
+- Understand the Web/CLI paths: [Architecture](architecture.en.md)
+- Understand model, effort, and statusline sources: [Display contracts](display-contracts.md) (Chinese)
+- Review every environment variable: [`.env.example`](../.env.example)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,274 @@
+# 首次使用指南
+
+> 目标：从一个已经能运行 `claude` 的电脑开始，把 Claude Chat Mobile 启动起来，并从手机发出第一条消息。
+
+[English](getting-started.en.md) · [返回 README](../README.md)
+
+## 完成后你会得到什么
+
+- 一个只在你电脑上运行的 Claude Chat Mobile server。
+- 一个受 `AUTH_TOKEN`、工作区白名单和设备审批保护的手机入口。
+- 与本机 `claude` CLI 共用配置、工具和落盘会话记录的 Web 界面。
+
+本指南覆盖首次安装。已经用 LaunchAgent/systemd 常驻部署的实例不要再手动运行 `npm start`，请按[部署指南](deployment.md)重启服务。
+
+## 1. 检查前置条件
+
+```bash
+node --version
+which claude
+claude --version
+```
+
+需要满足：
+
+- Node.js ≥ 20。
+- `which claude` 能找到本机 CLI。
+- `claude` 已登录，能在终端正常开始一次对话。
+- macOS 或 Linux。原生 Windows 属实验路径，推荐 WSL2。
+
+项目不自带 Claude，也不会替你安装或登录 CLI。
+
+### 官方订阅与第三方网关
+
+- 官方订阅：确保启动 server 的本机账号已经登录 `claude`，无需再配 API key。
+- 第三方网关：先在**将要启动 server 的 shell** 中导出网关要求的 `ANTHROPIC_*`，再启动项目。
+- 不要把 `ANTHROPIC_*` 写进项目 `.env`：启动时会主动剥除这些值，避免项目文件覆盖 CLI/provider 环境。
+
+## 2. 获取代码与安装依赖
+
+```bash
+git clone https://github.com/Ike-li/claude-chat-mobile.git
+cd claude-chat-mobile
+npm install --omit=dev
+```
+
+`--omit=dev` 只安装运行依赖，不下载 Playwright 浏览器。需要参与开发或运行测试时再使用完整的 `npm install`。
+
+## 3. 生成本地配置
+
+### 交互式向导
+
+在真实终端里运行：
+
+```bash
+npm run setup
+```
+
+向导会：
+
+1. 生成随机 `AUTH_TOKEN` 并写入 `.env`，文件权限设为 `0600`。
+2. 询问 `WORK_DIR`。请选择明确的项目目录，不要把整个家目录作为方便的默认范围。
+3. 询问是否安装 CLI hooks bridge。默认安装，但只有你确认后才会写 `~/.claude/settings.json`。
+
+如果 `.env` 已存在，向导默认不覆盖。
+
+### 非交互模式
+
+编程 agent、CI shell 或其他没有 TTY 的环境必须显式使用：
+
+```bash
+node scripts/setup.js \
+  --yes \
+  --work-dir=/绝对路径/到/项目 \
+  --hooks=off
+```
+
+- `--work-dir` 必填，不会静默回落到 `$HOME`。
+- `--hooks` 只接受 `on` 或 `off`；`on` 会修改用户级 Claude hooks 配置。
+- 已有 `.env` 时命令会拒绝覆盖。只有确认要替换现有 token 与配置时才加 `--force`。
+- 可用 `--env <path>` 指定其他环境文件。
+
+多工作区推荐在 `.env` 设置 `WORK_DIRS_FILE=workdirs.json`，文件内容为绝对路径数组：
+
+```json
+[
+  "/Users/you/code/project-a",
+  {
+    "path": "/Users/you/code/project-b",
+    "sessionLimit": 10
+  }
+]
+```
+
+`workdirs.json` 支持热加载。git worktree 也必须作为独立绝对路径显式加入；项目不会自动发现或放行。
+
+## 4. 运行启动自检
+
+```bash
+node scripts/doctor.js
+```
+
+它会检查 token、CLI 路径、工作区、端口、网关环境、文件权限、bridge 状态和文档/前端一致性。
+
+权限类问题可让 doctor 做最小修复：
+
+```bash
+node scripts/doctor.js --fix
+```
+
+`--fix` 会收紧 `.env` 与控制面 JSON 文件权限；先阅读输出，再决定是否运行。
+
+## 5. 启动 server
+
+首次本地试用：
+
+```bash
+npm start
+```
+
+默认监听 `3000` 端口。启动日志应显示：
+
+- server 已监听；
+- 脱敏后的 token 状态；
+- 可在手机打开的局域网 URL；
+- bridge 与待审批设备状态。
+
+设有 `AUTH_TOKEN` 时，健康检查也需要鉴权：
+
+```bash
+curl -sS "http://127.0.0.1:3000/health?token=<AUTH_TOKEN>"
+```
+
+返回包含 `status`、`versions`、`buildNonce` 与 `timestamp` 的 JSON 才算 server 已正常响应。`AUTH_TOKEN` 等同本机 shell 入口密钥，不要把真实值贴到 issue、聊天记录或截图中。
+
+如果这台机器已经有 LaunchAgent/systemd 常驻实例，3000 端口通常已被占用。不要启动第二个 server；按[部署指南的运维速查](deployment.md#运维速查)重启现有服务。
+
+## 6. 从手机打开
+
+### 同一 WiFi
+
+直接打开启动日志给出的地址：
+
+```text
+http://<lan-ip>:3000/#token=<AUTH_TOKEN>
+```
+
+首次加载后 token 会存入浏览器 `localStorage`，并从地址栏清除。
+
+### 临时 HTTPS
+
+PWA 或 Web Push 需要 HTTPS。临时试用可在另一个终端运行：
+
+```bash
+cloudflared tunnel --url http://localhost:3000
+```
+
+然后打开：
+
+```text
+https://<random>.trycloudflare.com/#token=<AUTH_TOKEN>
+```
+
+随机隧道适合测试，域名每次启动都可能变化，也没有 Cloudflare Access；设备审批仍然生效。固定域名、Access 2FA 与常驻服务见[部署指南](deployment.md)。
+
+## 7. 批准手机设备
+
+手机首次从非本机路径连接时会显示等待批准。回到电脑运行：
+
+```bash
+node scripts/device.js list
+node scripts/device.js approve <ID>
+```
+
+先核对待审设备 ID，再批准。批准后页面会立即解锁，不需要重新输入 token。
+
+如批准错设备或设备丢失：
+
+```bash
+node scripts/device.js deny <ID>
+```
+
+本机 loopback 和已经通过 Cloudflare Access JWT 的公网连接会跳过设备审批；普通局域网和临时随机隧道不会。
+
+## 8. 完成首次验收
+
+在手机上依次确认：
+
+1. 首页显示预期工作区。
+2. 新建会话并发送一个无副作用的问题，例如“只回复 OK”。
+3. 能看到流式回答和回合结束状态。
+4. 打开设置，确认模型、权限档、思考强度和服务状态可见。
+5. 如已启用 Web Push，使用“发一条测试推送”验证通道，不要等真实审批出现才发现配置有误。
+
+到这里，最小可用路径已经完成。下面两座 bridge 都是可选增强，不影响 Web 自己发起会话。
+
+## 可选：CLI statusline bridge
+
+Web 驾驶的会话开箱即用 SDK 状态栏。只有当你还想在 Web **只读查看终端正在运行的会话**时同步 CLI 的模型、思考强度、上下文、成本和额度，才需要 statusline bridge。
+
+```bash
+npm run statusline:status
+npm run statusline:install
+```
+
+- `status` 只读，不改 `~/.claude`。
+- `install` 是显式 opt-in，会包装已有的 Claude CLI statusline 命令；未配置 statusline 时安装器会拒绝。
+- 安装后重开终端里的 Claude CLI，并重启常驻 server。
+- 卸载用 `npm run statusline:uninstall`，安装器会按 manifest 恢复原命令并拒绝覆盖发生漂移的配置。
+
+## 可选：CLI hooks bridge
+
+未安装 hooks 时，server 仍会每 2.5 秒轮询 transcript；但终端回合的 Stop / Notification 不会主动叫醒手机。安装 bridge 后，CLI 会把这两类事件写入受限文件投递箱，server 立即消费并按通知设置处理。
+
+```bash
+npm run hooks:status
+npm run hooks:install
+npm run hooks:verify
+npm run hooks:uninstall
+```
+
+- `status` 只读。
+- `install` 只追加自己的 hook 条目，保留已有 hooks，并自动做回环验证。
+- 安装后必须新开终端里的 Claude CLI 会话，旧进程不会重新加载 hooks。
+- server 不在线时 hook 只落盘并静默退出，不阻断 CLI。
+- `.env` 设 `CLI_HOOKS_BRIDGE=off` 可让 server 暂停消费，不必卸载全局配置。
+
+手机端也可在“设置 → 服务状态 → 终端会话推送”中显式安装或卸载。
+
+<details>
+<summary>把首次安装交给编程 agent</summary>
+
+在仓库目录中把下面内容交给 Claude Code、Codex CLI 或其他本机编程 agent：
+
+```text
+帮我首次安装并启动 claude-chat-mobile（把本机 claude CLI 接到手机 Web UI）。
+这是全新环境首次安装，不是重启已部署的常驻服务。
+
+按顺序做，每步确认结果再进入下一步：
+1. 检查 node --version ≥ 20，which claude 能找到命令，并确认 claude 已登录。
+   任一不满足就停下来告诉我，不要自行安装或登录 claude。
+2. 运行 npm install --omit=dev。
+3. 先跟我确认 WORK_DIR 的绝对路径，以及是否安装 CLI hooks bridge。
+   不要把整个家目录当 WORK_DIR；hooks=on 会修改 ~/.claude/settings.json。
+4. 你的 shell 没有 TTY，不要运行交互向导。使用：
+   node scripts/setup.js --yes --work-dir=<确认后的绝对路径> --hooks=<on 或 off>
+   如果 .env 已存在就停下来，不要自行加 --force。
+5. 运行 node scripts/doctor.js；只在输出明确要求且安全时使用 --fix。
+6. 确认没有常驻服务占用端口后，在后台启动 server。用鉴权后的 /health JSON 验证，
+   不要只看进程是否存在。
+7. 告诉我启动日志中的局域网手机地址，但不要把 AUTH_TOKEN 写进任何会外传的文件或报告。
+8. 等我的手机发起连接后，运行 node scripts/device.js list；让我核对设备，再执行 approve。
+固定公网域名和常驻部署按 docs/deployment.md 处理，不要擅自改系统服务。
+```
+
+</details>
+
+## 常见问题
+
+| 现象 | 检查 |
+|---|---|
+| 启动日志没有手机地址 | `AUTH_TOKEN` 未设置；重新运行 setup 或修正 `.env` 后重启 |
+| agent 运行 setup 后什么都没写 | 非 TTY 环境用了交互模式；改用 `--yes --work-dir=... --hooks=...` |
+| `EADDRINUSE :3000` | 已有常驻服务或其他进程占用端口；不要盲目再启动 |
+| 手机一直等待审批 | 运行 `device.js list`，核对并批准正确 ID |
+| 第三方网关配置不生效 | `ANTHROPIC_*` 必须来自启动 server 的 shell，不是 `.env` |
+| CLI 会话状态或通知缺失 | 分别检查 statusline bridge 与 hooks bridge；两者用途不同 |
+| Android 安装后只是浏览器快捷方式 | Cloudflare Access 可能拦住 PWA 图标，见[部署指南](deployment.md#2b-android-pwa图标必须对匿名可达) |
+
+## 下一步
+
+- 长期公网使用：[部署与运维](deployment.md)
+- 理解 Web/CLI 双通道：[架构说明](architecture.md)
+- 理解模型、effort、statusline 展示来源：[展示契约](display-contracts.md)
+- 查看所有环境变量：[`.env.example`](../.env.example)

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -36,7 +36,7 @@ This is the source of truth for what belongs in the repository. Run `npm run inv
 | Backend source | 53 |
 | Configuration template | 1 |
 | Deployment | 3 |
-| Documentation | 5 |
+| Documentation | 9 |
 | E2E test | 42 |
 | Frontend asset | 3 |
 | Frontend source | 22 |
@@ -55,7 +55,7 @@ This is the source of truth for what belongs in the repository. Run `npm run inv
 | Unit test | 123 |
 | Vendored asset | 21 |
 
-Total classified files: **354**.
+Total classified files: **358**.
 
 ## Complete file inventory
 
@@ -70,8 +70,12 @@ Total classified files: **354**.
 | `deploy/log-rotate.plist.template` | Deployment | Service manager deployment template | LaunchAgent or systemd installation | Authored and reviewed manually | keep |
 | `deploy/server.plist.template` | Deployment | Service manager deployment template | LaunchAgent or systemd installation | Authored and reviewed manually | keep |
 | `deploy/tunnel.plist.template` | Deployment | Service manager deployment template | LaunchAgent or systemd installation | Authored and reviewed manually | keep |
+| `docs/architecture.en.md` | Documentation | English explanation of Web/CLI data paths, ownership, and replay | README, documentation site, or maintainer reference | Authored and reviewed manually | keep |
+| `docs/architecture.md` | Documentation | Chinese explanation of Web/CLI data paths, ownership, and replay | README, documentation site, or maintainer reference | Authored and reviewed manually | keep |
 | `docs/deployment.md` | Documentation | Persistent service, tunnel, and Cloudflare Access operations guide | README, documentation site, or maintainer reference | Authored and reviewed manually | keep |
 | `docs/display-contracts.md` | Documentation | Display contracts: model / effort / statusline TUI–SDK–FE rules and test anchors | README, documentation site, or maintainer reference | Authored and reviewed manually | keep |
+| `docs/getting-started.en.md` | Documentation | English first-run tutorial from installation through phone validation | README, documentation site, or maintainer reference | Authored and reviewed manually | keep |
+| `docs/getting-started.md` | Documentation | Chinese first-run tutorial from installation through phone validation | README, documentation site, or maintainer reference | Authored and reviewed manually | keep |
 | `docs/repository-map.md` | Generated documentation | Exhaustive repository file map | README, documentation site, or maintainer reference | `npm run inventory:update` | generated |
 | `eslint.config.js` | Project configuration | ESLint flat config (npm run check static gate) | `npm run check` / `npm run lint` | Authored and reviewed manually | keep |
 | `LICENSE` | Legal | Project license | Referenced by maintainers | Authored and reviewed manually | keep |

--- a/package-lock.json
+++ b/package-lock.json
@@ -330,13 +330,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -409,13 +409,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -644,20 +644,20 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -667,17 +667,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -1385,9 +1398,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/scripts/repo-inventory.js
+++ b/scripts/repo-inventory.js
@@ -30,8 +30,12 @@ const ROOT_FILES = new Map([
   ['.nvmrc', ['Project configuration', 'Recommended Node major version', 'keep']],
   // docs/ 手写文档逐篇显式登记（无 .md 通配）：往 docs/ 新增文档必须先在此声明用途，
   // 否则 inventory:check 拒绝——挡住审计报告/进度笔记/提案等一次性产物悄悄回堆。
+  ['docs/architecture.en.md', ['Documentation', 'English explanation of Web/CLI data paths, ownership, and replay', 'keep']],
+  ['docs/architecture.md', ['Documentation', 'Chinese explanation of Web/CLI data paths, ownership, and replay', 'keep']],
   ['docs/deployment.md', ['Documentation', 'Persistent service, tunnel, and Cloudflare Access operations guide', 'keep']],
   ['docs/display-contracts.md', ['Documentation', 'Display contracts: model / effort / statusline TUI–SDK–FE rules and test anchors', 'keep']],
+  ['docs/getting-started.en.md', ['Documentation', 'English first-run tutorial from installation through phone validation', 'keep']],
+  ['docs/getting-started.md', ['Documentation', 'Chinese first-run tutorial from installation through phone validation', 'keep']],
 ]);
 
 const PREFIX_RULES = [

--- a/src/server/http.js
+++ b/src/server/http.js
@@ -1,7 +1,7 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { readdirSync, readFileSync } from 'node:fs';
 import { networkInterfaces } from 'node:os';
-import { join } from 'node:path';
+import { join, relative, sep } from 'node:path';
 import compression from 'compression';
 import express from 'express';
 
@@ -223,20 +223,24 @@ export function configureHttpShell({
     return res.type('application/javascript').send(appJs);
   });
   // 子模块也改写相对 import 的 ?v=，避免 connection-sync 拉到未戳版本的 logic.js 双实例。
+  // 与上面的 indexHtml/appJs 一样启动时读完，请求期只查表：这条路由排在鉴权之前（静态资源必须
+  // 登录前可取），每请求 readFileSync 会让未鉴权的高频请求同步阻塞事件循环。
+  // 「改了 js 要重启」不是新增约束——assetVersion 本就是启动时哈希算的，不重启 ?v= 也不换。
+  const selfJsSources = new Map();
+  for (const path of listJsFilesRecursive(selfJsDir)) {
+    const rel = relative(selfJsDir, path).split(sep).join('/');
+    try {
+      selfJsSources.set(rel, rewriteAppModuleImports(readFileSync(path, 'utf8'), assetVersion));
+    } catch { /* 单个文件读不出就当它不存在，落到下面的 static 404 */ }
+  }
   app.get(/^\/js\/.+\.js$/, (req, res, next) => {
     if (req.path === '/js/app.js') return next(); // 上面专用路由已处理
     const rel = req.path.replace(/^\/js\//, '');
     if (rel.includes('..')) return res.status(400).end();
-    try {
-      const source = rewriteAppModuleImports(
-        readFileSync(join(selfJsDir, rel), 'utf8'),
-        assetVersion,
-      );
-      res.setHeader('Cache-Control', 'no-cache');
-      return res.type('application/javascript').send(source);
-    } catch {
-      return next(); // 交给 static 404
-    }
+    const source = selfJsSources.get(rel);
+    if (source === undefined) return next(); // 交给 static 404
+    res.setHeader('Cache-Control', 'no-cache');
+    return res.type('application/javascript').send(source);
   });
   app.use(express.static(publicDir, {
     setHeaders: (res, filePath) => {

--- a/tests/unit/server-http.test.mjs
+++ b/tests/unit/server-http.test.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 import {
+  configureHttpShell,
   createHttpAuth,
   rewriteAppModuleImports,
   rewriteIndexAssetUrls,
@@ -263,5 +267,74 @@ test.describe('/push/subscribe 的第二因子：bypass 级信任必须与信任
     const { run, saved } = mount({ isDeviceTrusted: () => true, bypassDeviceApproval: () => false });
     assert.equal(run().status, 200);
     assert.equal(saved.length, 1);
+  });
+});
+
+// /js/** 子模块路由：源码在启动时读完并做完 ?v= 改写，请求期只查表。
+// 每请求 readFileSync 是同步阻塞事件循环的磁盘访问，而这条路由在鉴权之前（静态资源必须登录前可取），
+// 与同文件里 indexHtml/appJs 的启动预读也不一致。「改了 js 要重启」不是新约束——assetVersion 本就是
+// 启动时哈希算的，不重启 ?v= 也不换。
+test.describe('configureHttpShell 的 /js/** 子模块路由', () => {
+  const roots = [];
+  test.after(() => { for (const dir of roots) rmSync(dir, { recursive: true, force: true }); });
+
+  function mount() {
+    const root = mkdtempSync(join(tmpdir(), 'ccm-http-shell-'));
+    roots.push(root);
+    mkdirSync(join(root, 'public/js/app'), { recursive: true });
+    writeFileSync(join(root, 'public/index.html'), '<body ><script src="/js/app.js"></script></body>');
+    writeFileSync(join(root, 'public/js/app.js'), "import './app/sub.js';\n");
+    writeFileSync(
+      join(root, 'public/js/app/sub.js'),
+      "import { esc } from '../logic.js';\nexport const BUILD = 'startup';\n",
+    );
+
+    const routes = new Map();
+    const app = { use: () => {}, get: (p, ...h) => routes.set(String(p), h) };
+    configureHttpShell({ app, projectRoot: root, isAccessEnabled: () => false });
+
+    const handlers = routes.get(String(/^\/js\/.+\.js$/));
+    assert.ok(handlers, '未注册 /js/** 子模块路由');
+    const run = path => {
+      const out = { status: 200, body: null, headers: new Map(), nextCalled: false };
+      const res = {
+        status(c) { out.status = c; return this; },
+        setHeader(k, v) { out.headers.set(k, v); return this; },
+        type() { return this; },
+        send(b) { out.body = b; return this; },
+        end() { return this; },
+      };
+      handlers[handlers.length - 1]({ path }, res, () => { out.nextCalled = true; });
+      return out;
+    };
+    return { root, run };
+  }
+
+  test('请求期零磁盘访问：启动后改盘，路由仍发启动时那份（且相对 import 已戳版本）', () => {
+    const { root, run } = mount();
+    writeFileSync(join(root, 'public/js/app/sub.js'), "export const BUILD = 'mutated-after-boot';\n");
+
+    const out = run('/js/app/sub.js');
+    assert.equal(out.status, 200);
+    assert.match(out.body, /BUILD = 'startup'/);
+    assert.doesNotMatch(out.body, /mutated-after-boot/, '请求期又去读盘了');
+    assert.match(out.body, /from '\.\.\/logic\.js\?v=[0-9a-f]{8}'/);
+    assert.equal(out.headers.get('Cache-Control'), 'no-cache');
+  });
+
+  test('路径穿越照旧 400（显式防线不因查表而失效）', () => {
+    const out = mount().run('/js/../../etc/passwd.js');
+    assert.equal(out.status, 400);
+    assert.equal(out.nextCalled, false);
+  });
+
+  test('表里没有的子模块交给 static 去 404', () => {
+    const out = mount().run('/js/never-existed.js');
+    assert.equal(out.nextCalled, true);
+    assert.equal(out.body, null);
+  });
+
+  test('/js/app.js 让给上面的专用路由', () => {
+    assert.equal(mount().run('/js/app.js').nextCalled, true);
   });
 });


### PR DESCRIPTION
dev 领先 master 6 个 commit，可 ff。本次无破坏性变更、无新增依赖、无 API 契约改动。

## 变更

**文档**
- README 瘦身为入口，拆出首次使用指南与架构说明（中英各一份）
- 移除 `README.en.md` 失效的英雄图引用 —— gh-pages 上从无 `assets/hero-en.jpg`，实测该 URL 恒 404，英文 README 顶部一直是破图。未复用 `hero-zh.jpg`（图上主标题与手机 UI 全中文，给英文读者观感差）

**性能**
- `/js/**` 子模块源码改启动时预读，请求期零磁盘访问。该路由排在鉴权之前（静态资源必须登录前可取），此前每请求 `readFileSync` 会让未鉴权的高频请求同步阻塞事件循环

**CI / 依赖**
- `test.yml` 加顶层 `permissions: contents: read`，收窄 `GITHUB_TOKEN`
- `npm audit fix` 清掉 4 条依赖告警（仅传递依赖，直接依赖不动）

## 验证

`npm run check` 全绿：模块边界无跨层违规无循环依赖 · `agent:event` 出向契约 26/26 · 入向 socket 契约 40/40 · 文档一致性 12 篇 · i18n 624 词条无孤儿 · visual mock registry · Playwright 禁止模式 · inventory 358 文件。

合并门禁由本 PR 的 `unit-test` 与 `e2e` 两个 check 把关。