### PR TITLE
CI 增强：拆 quality job、Node 20/24 矩阵、timeout/concurrency，并修矩阵挖出的 Node 20 真 bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,46 @@ on:
 permissions:
   contents: read
 
+# 连推时取消同分支的旧 run，只留最新一次的反馈。
+# master 例外：发版那次的完整 run 记录要留着，被后续推送腰斩就查不了了。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
-  unit-test:
+  # npm run check 从 e2e 里拆出来独立成 job：它是零 token、本机几秒跑完的静态闸，
+  # 此前却排在 `playwright install --with-deps chromium` 之后，语法错也要等浏览器装完才报。
+  # 拆开后 quality 先红，省掉整轮 e2e 的等待。
+  # ★ 拆走后 e2e 不再跑 check —— master 分支保护的 required contexts 必须含 quality，
+  #   否则出现「check 红了 PR 照样能合」。改这个 job 名必须同步改分支保护。
+  quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+
+  unit-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      # engines 声明 ">=20"（给自托管用户的承诺：Ubuntu/Debian 仓库里常见的就是 20），
+      # 但 7/31 修 force-exit 竞态时把 CI 从 20 升到了 24，此后 20 再没被验证过。
+      # 矩阵补回这个缺口：engines 承诺什么，CI 就得跑什么。
+      # fail-fast: false —— 20 挂了也要看到 24 的结果，才能区分「只有旧版挂」和「全挂」。
+      fail-fast: false
+      matrix:
+        node: ['20', '24']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci
       # 不跑 `npm test`（= unit + integration 且带 --test-force-exit）。force-exit 是为集成测试
@@ -26,10 +58,14 @@ jobs:
       # 「fail 0 但 cancelled 5」，exit 1。7/30 起 CI 连红即此，与被测代码无关。
       # test:unit 本就不带该 flag，拆开跑即可，防挂死保护仍留在 integration 上。
       - run: npm run test:unit
+      # 注：CI 上这一步几乎全被 skip（21 个集成文件多数带 `process.env.CI ? {skip}`，实测
+      # 30 suites 只出 3 tests）—— runner 上没有本机 claude CLI，这是有意的设计边界，
+      # 不是疏漏。真实集成覆盖靠本机 `npm test` 与 `npm run test:smoke`。
       - run: npm run test:integration
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
@@ -42,10 +78,6 @@ jobs:
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
-
-      # 顺带把 npm run check（语法/文档一致性/mock registry guard/TC-007 test.fixme 等禁止模式硬闸）
-      # 接入 CI——此前它只在本机跑，CI 从未验证过。
-      - run: npm run check
 
       - name: Run Playwright E2E
         run: npm run test:e2e

--- a/tests/helpers/agent-unit.mjs
+++ b/tests/helpers/agent-unit.mjs
@@ -36,11 +36,25 @@ export function makeSession(opts = {}) {
 // 则是 approvalStore.recordCreated 的异步落盘 I/O 恰好撑住了事件循环。两者都不是保证。
 //
 // 真实 server 靠 listening socket 撑着事件循环，这里用一个 ref'd interval 还原同一前提。
-export async function awaitTtlSettled(promise) {
-  const keepAlive = setInterval(() => {}, 1000);
+//
+// ★ keepAlive 必须有界。若 TTL 真的回归、promise 永不 settle（正是这些用例要抓的失败），
+// 控制流到不了 finally，这个 ref'd interval 就永不清除：node:test 照常报 per-test timeout，
+// 但进程被它吊住不退出，job 一路挂到 CI 的 timeout-minutes。实测过——测试 1s 就判失败，
+// 进程 20s 后仍在，得靠外部杀。等于把几秒的局部失败换成挂死的 job。
+// 所以用 budgetMs 兜底：到点主动 reject，finally 清掉 handle，进程照常退出，
+// 且错误信息比 node:test 的泛型 timeout 更能指认病灶。budgetMs 需小于用例自己的 timeout。
+export async function awaitTtlSettled(promise, budgetMs = 2000) {
+  const keepAlive = setInterval(() => {}, 50);
+  let bail;
   try {
-    return await promise;
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        bail = setTimeout(() => reject(new Error(`TTL 未在 ${budgetMs}ms 内结算——到期 timer 没触发`)), budgetMs);
+      }),
+    ]);
   } finally {
     clearInterval(keepAlive);
+    clearTimeout(bail);
   }
 }

--- a/tests/helpers/agent-unit.mjs
+++ b/tests/helpers/agent-unit.mjs
@@ -23,3 +23,24 @@ export function makeSession(opts = {}) {
   });
   return { s: session, events, dispose: () => session.dispose() };
 }
+
+// 等一个「只能由 TTL 到期 timer 结算」的 Promise。
+//
+// 产品侧那些 expiryTimer 都调了 .unref()（agent.js:886/1021），这是对的：30 分钟的审批 TTL
+// 不该拖住 server 进程退出。但测试里 await 它就踩了 unref 的语义——事件循环若没有别的 ref'd
+// handle，Node 判定「无事可做」直接收尾，于是该用例连同其后同 suite 的用例全报
+// failureType: 'cancelledByParent'（不是断言失败，`fail 0` 却 `exit 1`）。
+//
+// Node 20 CI 上确定性复现：两次独立跑都是同一批 5 个（agent-questions 的 not ok 12-16）。
+// 之所以别处没炸只是侥幸——Node 24 的 test runner 内部持有 ref'd handle；askPermission 那几个
+// 则是 approvalStore.recordCreated 的异步落盘 I/O 恰好撑住了事件循环。两者都不是保证。
+//
+// 真实 server 靠 listening socket 撑着事件循环，这里用一个 ref'd interval 还原同一前提。
+export async function awaitTtlSettled(promise) {
+  const keepAlive = setInterval(() => {}, 1000);
+  try {
+    return await promise;
+  } finally {
+    clearInterval(keepAlive);
+  }
+}

--- a/tests/unit/agent-permissions.test.mjs
+++ b/tests/unit/agent-permissions.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { makeSession } from '../helpers/agent-unit.mjs';
+import { makeSession, awaitTtlSettled } from '../helpers/agent-unit.mjs';
 
 // ---- 权限闸门 ----
 test.describe('权限闸门', () => {
@@ -130,7 +130,9 @@ test.describe('权限闸门', () => {
     // 纯靠到期 timer 结算：全程【不】调用 resolvePermission，模拟无人处理审批的场景。
     const promise = s.askPermission('Bash', { command: 'sleep 999' }, { signal: ac.signal, toolUseID: 't1' });
     assert.equal(s.pendingPermissions.size, 1, '刚请求时应挂起');
-    const result = await promise; // 无到期 timer 时此处永不 resolve（靠 test timeout 兜底红）
+    // 同 agent-questions 的 AG-001：expiryTimer 是 unref 的，此处仅靠 approvalStore 落盘 I/O
+    // 侥幸撑住事件循环，不是保证 —— 用 helper 显式还原前提。无到期 timer 时此处永不 resolve（靠 test timeout 兜底红）。
+    const result = await awaitTtlSettled(promise);
     assert.equal(result.behavior, 'deny', '到期后 fail-closed deny');
     assert.equal(result.interrupt, false, 'expired 不 interrupt 在途轮');
     assert.equal(s.pendingPermissions.size, 0, '到期后 pending 清空，不再悬置');
@@ -286,7 +288,8 @@ test.describe('权限闸门', () => {
       const ac = new AbortController();
       const promise = s.askPermission('Bash', { command: 'ls' }, { signal: ac.signal, toolUseID: 'store-t5' });
       // BE-003：到期由 timer 主动结算（不再依赖有人提交才惰性发现过期）——await 到 Promise 被 timer resolve。
-      const result = await promise;
+      // expiryTimer 是 unref 的，同上用 helper 撑住事件循环。
+      const result = await awaitTtlSettled(promise);
       assert.equal(result.behavior, 'deny', '过期 fail-closed deny');
       assert.equal(AS.getByReqId('store-t5').status, 'expired', '台账记 expired');
       // 过期后再提交（即便 allow）扑空——已被 timer 结算，返回 undefined，绝不放行（fail-closed 保证仍在）。

--- a/tests/unit/agent-questions.test.mjs
+++ b/tests/unit/agent-questions.test.mjs
@@ -4,7 +4,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { makeSession } from '../helpers/agent-unit.mjs';
+import { makeSession, awaitTtlSettled } from '../helpers/agent-unit.mjs';
 
 // ---- AskUserQuestion ----
 test.describe('AskUserQuestion', () => {
@@ -208,7 +208,7 @@ test.describe('AskUserQuestion', () => {
       { signal: ac.signal, toolUseID: 'q1' },
     );
     assert.equal(s.pendingQuestions.size, 1);
-    const result = await promise;
+    const result = await awaitTtlSettled(promise); // 见 helper 注释：expiryTimer 是 unref 的
     assert.equal(result.behavior, 'deny');
     assert.equal(result.interrupt, false);
     assert.equal(s.pendingQuestions.size, 0);


### PR DESCRIPTION
dev 领先 master 2 个 commit，可 ff。改动集中在 CI 配置与测试基建，**不含任何产品代码变更**。

## 变更

**`.github/workflows/test.yml`**

- **拆 `quality` job**：`npm run check` 从 e2e 里独立出来。它是零 token、几秒跑完的静态闸，此前却排在 `playwright install --with-deps chromium` 之后，语法错也要等浏览器装完才报。
- **Node 20/24 矩阵**：`engines` 声明 `">=20"`（给自托管用户的承诺，Ubuntu/Debian 仓库里常见的就是 20），但 7/31 修 CI 时把 runner 从 20 升到了 24，此后 20 再没被验证过。矩阵补回这个缺口。`fail-fast: false` 以便区分「只有旧版挂」和「全挂」。
- **`timeout-minutes`**（quality 10 / unit 15 / e2e 25）：此前无 timeout，挂死的 job 会跑满 GitHub 默认 6 小时。集成测试确实挂死过，`--test-force-exit` 就是为它加的。
- **`concurrency`**：连推时取消同分支旧 run；`master` 例外，发版那次的完整记录要留着。

**`tests/`：修矩阵第一次跑就挖出的 Node 20 真 bug**

`unit-test (20)` 首跑即红，两次独立跑确定性复现同一批：`agent-questions` 的 `not ok 12-16` + 父 suite，`failureType` 全是 `cancelledByParent`——报出来是「`fail 0` 但 `cancelled 5`，`exit 1`」。

根因**不是** `--test-force-exit`。产品侧 `expiryTimer` 调了 `.unref()`（`agent.js:886`/`:1021`），这是对的：30 分钟的审批 TTL 不该拖住 server 退出。但测试 `await` 的正是这个 Promise，而 `unref()` 的语义就是「事件循环只剩我时别为我保持存活」——没有别的 ref'd handle 时 Node 判定无事可做直接收尾，该用例连同其后同 suite 的用例全被取消。

7/31 那次把 CI 从 `npm test` 拆成 `test:unit` + `test:integration` 后转绿，被归因为去掉了 force-exit。矩阵做出的干净对照证明真正起作用的是**同时把 CI 从 20 升到了 24**：

| | 结果 |
|---|---|
| Node 24 + `test:unit` | pass 2257 |
| Node 20 + `test:unit`（同样不带 force-exit） | cancelled 5, exit 1 |

一并修了 `agent-permissions` 的两处同构用例。它们没炸只是侥幸——`askPermission` 会走 `approvalStore.recordCreated` 的异步落盘，那个 I/O handle 恰好撑住了事件循环；`handleQuestion` 不写台账所以没有。台账写入哪天变快或改同步，它们就是同样的雷。

修法：helper `awaitTtlSettled()` 用一个 ref'd interval 还原真实 server 由 listening socket 撑住事件循环的前提。

## 验证

修复后 Node 20：`cancelled 5 → 0`，`pass 2252 → 2257`，`fail 0`。

本机 Node 25 复现不了该问题（`pass 2257 / cancelled 0`），所以本机绿只证明无回归，真正的判据是 CI 的 `unit-test (20)`。

## 附带说明

合并门禁已同步为四个 check：`quality` / `unit-test (20)` / `unit-test (24)` / `e2e`，与 workflow 实际上报的 job 名逐字比对确认一致（矩阵会把 job 名变成 `unit-test (20)` 这种形式，不同步改分支保护就会出现永不上报的必需检查）。