### PR TITLE
发版前校验 origin/dev 的 CI 全绿，附 --skip-ci-check 直发口子

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,16 @@ Agent SDK：https://code.claude.com/docs/en/agent-sdk/overview，尽量不要重
 
 ## 分支纪律
 
-**日常开发一律在 `dev` 分支，不要在 `master` 上直接改**（`master` = 稳定分支 / GitHub 默认 / `clone` 默认拿到，有分支保护）。功能做完再由 `dev` ff 合并进 `master` 并发版（用 `scripts/release.sh`）。
+**日常开发在 `feature/xxx` 分支上，经 PR 进 `dev`；`dev`/`master` 都不要直接改**（`master` = 稳定分支 / GitHub 默认 / `clone` 默认拿到）。两层的规矩不一样：
+
+- **`feature/xxx` → `dev`**：从 `dev` 拉分支 → push → 开 PR → 等四个 check（`quality` / `unit-test (20)` / `unit-test (24)` / `e2e`）全绿 → **网页点合并，三种按钮都行**。这一层只往 `dev` 顶端追加 commit，不影响下面那条祖先关系。
+- **`dev` → `master`**：**不开 PR**，这是发版动作，跑 `scripts/release.sh`（bump 版本 → ff 合并 → 打 tag → 建 GitHub Release → 推两分支）。唯一硬约束是 `master` 必须是 `dev` 的祖先，由脚本自己做 ff 来保证。
+
+⚠️ 别用网页按钮合 `dev` → `master`：GitHub 的 "Rebase and merge" 总是生成新 commit SHA（官方文档明写），产物不是 `dev` 的后代，`master` 与 `dev` 就此分叉、只能靠强推 `dev` 收场；GitHub 全站没有 fast-forward-only 选项。真要走网页得先开 `allow_merge_commit`，且每次合完在本地补一句 `git checkout dev && git pull --ff-only origin master && git push origin dev`。
+
+⚠️ 两个分支的 `enforce_admins` 都是 `false`，所以分支保护**拦不住机主本人**——直接 push 只会回显 `Bypassed rule violations` 然后照常推上去。发版的真正闸门是 `release.sh` 里的 `CI=true npm test` 预检（红了 die 中止），不是分支保护。
+
+⚠️ 改 workflow 的 job 名（含加/减矩阵维度——矩阵会把名字变成 `unit-test (20)` 这种形式）必须**同步更新两个分支的 `required_status_checks.contexts`**，否则会造出永不上报的必需检查，PR 恒卡 pending。定 contexts 前先让 CI 真跑一次，照抄 `gh run view <id> --json jobs -q '.jobs[].name'`，不要凭记忆写。
 
 其他分支的常驻 worktree 检出位是仓库外的平级兄弟目录（`../claude-chat-mobile-<分支名>`，如 `claude-chat-mobile-promo`=宣传创作区、`claude-chat-mobile-gh-pages`=展示站、`claude-chat-mobile-third-party`=三方代理专用），**不是本分支源码**，物理上不在本仓库树内，开发/搜索/审查天然不会扫到，无需额外排除规则。
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,12 +5,14 @@
 # 发版 = 把 dev 快进合并进 master、打 tag、建 GitHub Release、两分支都推。
 #
 # 用法：
-#   scripts/release.sh [patch|minor|major|X.Y.Z] [--dry-run] [-y]
+#   scripts/release.sh [patch|minor|major|X.Y.Z] [--dry-run] [-y] [--skip-ci-check]
 #     位置参数=版本递增方式（默认 patch）；也可给显式版本号如 1.2.0
-#     --dry-run / -n   只做预检+CI模拟+显示计划，不改动任何东西
-#     -y / --yes       跳过交互确认（自动化用）
+#     --dry-run / -n     只做预检+CI校验+CI模拟+显示计划，不改动任何东西
+#     -y / --yes         跳过交互确认（自动化用）
+#     --skip-ci-check    跳过"origin/dev 的 CI 必须全绿"这道闸，直接发（紧急发版用）
 #
 # 内建护栏（都是踩过的坑）：
+#   · 默认要求 origin/dev 上那轮 CI 的必需 job 全绿，未跑完/红了都中止（--skip-ci-check 可跳）
 #   · 发版前 `CI=true npm test` 模拟 CI，红了就中止（防推完才发现 CI 挂）
 #   · 推 master 后用 `git ls-remote` 复核真到位了（git push 曾静默没推上去）
 #   · trap 保证任何中途退出都还原被 bump 的 package.json（不留脏工作树）
@@ -18,11 +20,12 @@
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
-BUMP="patch"; DRY=""; YES=""
+BUMP="patch"; DRY=""; YES=""; SKIP_CI=""
 for a in "$@"; do
   case "$a" in
     --dry-run|-n) DRY=1 ;;
     -y|--yes)     YES=1 ;;
+    --skip-ci-check) SKIP_CI=1 ;;
     patch|minor|major|*.*.*) BUMP="$a" ;;
     *) echo "✗ 未知参数：$a"; exit 2 ;;
   esac
@@ -68,6 +71,60 @@ for b in dev master; do
   R="$(git ls-remote origin "refs/heads/$b" | cut -f1)"
   [ -z "$R" ] || [ "$(git rev-parse "$b")" = "$R" ] || die "本地 $b 与 origin/$b 不一致，先同步"
 done
+
+# ── 远程 CI 结论校验（关键护栏，可用 --skip-ci-check 跳过）──────────────
+# 为什么查远程而不是本地重跑：dev 的 HEAD 推上去时 CI 已经跑过了（feature→dev 的 PR 一次、
+# 合入 dev 后 push 又一次），那轮覆盖含 e2e 在内的全部必需 job。本地重跑 e2e 要 ~9 分钟，
+# 且跑的是同一份东西，纯属重复劳动。这里一次 API 查询就够。
+#
+# ★ 必需 job 名【不在本脚本硬编码】，从 master 分支保护读——那才是"必需"的定义源。
+# workflow 改 job 名或加/减矩阵维度（矩阵会把名字变成 `unit-test (20)` 这种形式）时，
+# 只需改分支保护一处，脚本自动跟随。硬编码过一次就会重演 visual-e2e 那类永不上报的错配。
+#
+# ★ 为什么这道闸有必要：master 的分支保护对机主本人是失效的（enforce_admins=false），
+# 下面那句 git push 只会回显 "Bypassed rule violations" 然后照常推上去。真正的门就是这里。
+if [ -n "$SKIP_CI" ]; then
+  say "▶ 跳过远程 CI 校验（--skip-ci-check）—— 未经 CI 验证的代码将直接进 master"
+else
+  say "▶ 校验 origin/dev 的 CI 结论 …"
+  DEV_SHA="$(git rev-parse dev)"
+  REQ="$(gh api "repos/{owner}/{repo}/branches/master/protection/required_status_checks" -q '.contexts[]' 2>/dev/null || true)"
+  [ -n "$REQ" ] || die "读不到 master 的必需检查列表（分支保护未设？）——确认无误后可用 --skip-ci-check 跳过"
+  CHECKS="$(gh api "repos/{owner}/{repo}/commits/$DEV_SHA/check-runs" \
+              --jq '.check_runs[] | "\(.name)\t\(.status)\t\(.conclusion // "")"' 2>/dev/null || true)"
+  # ★ 同一个 commit 会有多轮 check suite（push dev 一轮、PR synchronize 一轮、ff 推 master 后
+  # 又一轮，因为 master 也在 on.push.branches 里），所以同名 job 会出现多条。这里【不能】取第一条
+  # 就收——万一 PR 那轮绿、push 那轮红，取到绿的就误放行了。判据是"任何一条不是 completed+success
+  # 就拦"：宁可误拦（历史红过、重跑才绿的情况），也不放过真红；误拦时看清楚了再用 --skip-ci-check。
+  BAD=""
+  while IFS= read -r n; do
+    [ -z "$n" ] && continue
+    seen="$(printf '%s\n' "$CHECKS" | awk -F'\t' -v n="$n" '$1 == n { c++ } END { print c+0 }')"
+    if [ "$seen" -eq 0 ]; then
+      BAD="$BAD  · $n —— 未上报（CI 可能还没触发，或 job 名与分支保护对不上）
+"
+      continue
+    fi
+    row="$(printf '%s\n' "$CHECKS" | awk -F'\t' -v n="$n" '$1 == n && ($2 != "completed" || $3 != "success") { print $2 "\t" $3; exit }')"
+    [ -z "$row" ] && continue
+    st="${row%%	*}"; cc="${row#*	}"
+    if [ "$st" != "completed" ]; then
+      BAD="$BAD  · $n —— $st（还在跑）
+"
+    else
+      BAD="$BAD  · $n —— $cc
+"
+    fi
+  done <<EOF
+$REQ
+EOF
+  if [ -n "$BAD" ]; then
+    printf '%s' "$BAD" >&2
+    say "  run: $(gh run list --commit "$DEV_SHA" --limit 1 --json url -q '.[0].url' 2>/dev/null || echo '（查不到 run 链接）')"
+    die "origin/dev 的 CI 未全绿，中止。等它跑完后重试，或确认无误后用 --skip-ci-check 直接发"
+  fi
+  say "  ✓ CI 全绿（$DEV_SHA 上的必需检查）"
+fi
 
 # ── 发版前 CI 模拟（关键护栏）──────────────────────────
 say "▶ 发版前模拟 CI：CI=true npm test …"


### PR DESCRIPTION
## 为什么

`master` 的分支保护**对机主本人是失效的**（`enforce_admins: false`）——`release.sh` 走的是 `git push` 不经 PR，只会回显 `Bypassed rule violations` 然后照常推上去。今天两次推 `master` 都实测如此。所以发版的真正门必须由脚本自己把。

## 改了什么

**`scripts/release.sh`**：默认新增一道预检——查 `origin/dev` HEAD 那个 commit 的 check runs，必需 job 全绿才放行；未跑完或红了都 `die`。紧急发版用 `--skip-ci-check` 跳过。

两个设计取舍：

- **查远程而非本地重跑**：`dev` 的 HEAD 推上去时 CI 已经跑过了（feature→dev 的 PR 一次、合入 dev 后 push 又一次），那轮覆盖含 `e2e` 在内的全部必需 job。本地重跑 e2e 要 ~9 分钟且是同一份东西。这里一次 API 查询就够。
- **必需 job 名不硬编码**，从 `master` 分支保护读——那才是「必需」的定义源。改 job 名或加/减矩阵维度（矩阵会把名字变成 `unit-test (20)` 这种形式）时只需改分支保护一处，脚本自动跟随。硬编码会重演 `visual-e2e` 那类永不上报的错配。

★ 一个实现细节值得留意：同一个 commit 会有**多轮** check suite（push `dev` 一轮、PR synchronize 一轮、ff 推 `master` 后又一轮，因为 `master` 也在 `on.push.branches` 里），所以同名 job 会出现多条。判据取「**任何一条**不是 `completed`+`success` 就拦」而非「取第一条」——否则 PR 那轮绿、push 那轮红时会误放行。

**`CLAUDE.md`**：同步更新分支纪律为 `feature`→PR→`dev`（该层三种合并按钮都行，只往 `dev` 顶端追加 commit，不影响「`master` 是 `dev` 祖先」这条约束）；`dev`→`master` 不开 PR，走 `release.sh`。

## 验证

shell 脚本本仓没有测试框架，故未走 TDD，替代验证策略：

- `bash -n` 与 `shellcheck -S warning` 均无告警
- 对当前 `dev` HEAD 实跑放行路径，正确读出四个必需检查并判定放行
- 四条判定路径用构造数据逐一验证：

| 场景 | 判定 |
|---|---|
| 全绿（多轮同名全 success） | 放行 |
| 多轮中有一轮红 | 拦截 `e2e —— failure` |
| 还在跑 | 拦截 `e2e —— in_progress（还在跑）` |
| 必需 job 未上报 | 拦截 `e2e —— 未上报` |