### PR TITLE
test: gate real-app browser chat E2E in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches: [master, dev]
   pull_request:
 
-# 两个 job 都只做 checkout/setup-node/npm/upload-artifact，不写回仓库任何东西，
+# 所有 job 只做 checkout/setup/test/upload-artifact，不写回仓库任何东西，
 # 所以把 GITHUB_TOKEN 收到最小面。（upload-artifact 走 ACTIONS_RUNTIME_TOKEN，不吃这里的权限。）
 permissions:
   contents: read
@@ -58,18 +58,12 @@ jobs:
       # 「fail 0 但 cancelled 5」，exit 1。7/30 起 CI 连红即此，与被测代码无关。
       # test:unit 本就不带该 flag，拆开跑即可，防挂死保护仍留在 integration 上。
       - run: npm run test:unit
-      # 集成测试是【唯一执行真实 app/src/server/app.js 的一层】：quality 是纯静态、test:unit 从不加载
-      # 那个文件、e2e 打的是 tests/e2e/mock/server.js 而非真 server。此前它在 CI 里被整体 skip
-      # （21 个文件全带 `process.env.CI ? {skip}`，实测 30 suites 只出 3 tests），于是仓库最大的
-      # 两个文件在 CI 零执行。2026-08-02 改：CLAUDE_BIN 指向 stub 让 preflight 过关，接线类测试
-      # 照常跑；真需要 agent turn 的仍由各文件自己的 RUN_CLAUDE_INTEGRATION 门跳过（不受这里影响）。
+      # 集成测试会执行真实 app/src/server/app.js；真需要 agent turn 的文件仍由
+      # RUN_CLAUDE_INTEGRATION 门控，CI 通过 CLAUDE_BIN stub 只验证零 token 接线。
       - run: npm run test:integration
         env:
           CLAUDE_BIN: ${{ github.workspace }}/tests/fixtures/fake-claude.sh
-      # ★ 覆盖率门槛的【唯一】自动执行点。doctor 的 D11 默认跳过它（装机预检不该让新用户等一分钟
-      #   单测），而 npm run check 的脚本链里从来没有它 —— 两件事叠起来就是门槛一个执行点都不剩。
-      #   排在 integration 之后：那是唯一执行真实 app/src/server/app.js 的一层，它红了比覆盖率跌了更该先看见。
-      #   只在 24 上跑：门槛是全仓一个数，两个 node 版本各算一遍只是把同一批单测再跑 70 秒。
+      # 覆盖率门槛只在 Node 24 上算一次。
       - run: node tests/gates/coverage-check.js
         if: matrix.node == '24'
 
@@ -99,3 +93,30 @@ jobs:
           name: playwright-e2e-report
           path: playwright-report/
           retention-days: 7
+
+  # 真实产品接线浏览器验收：Docker 内启动真正 app/server.js，走真实 HTTP/Socket、
+  # TOFU/device approve/workspace；Claude 仍用 fake-claude.sh，因此零 token、无外部凭据。
+  # 这条 lane 的目的不是替代 tests/e2e/mock，而是防 mock server 与 production server 协议漂移。
+  real-app-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run real-app playground E2E
+        run: npm run test:docker:playground
+
+      - name: Dump playground logs on failure
+        if: failure()
+        run: |
+          COMPOSE_PROFILES=mock,proxy docker compose \
+            -f tests/infra/docker-compose.playground.yml \
+            -f tests/infra/docker-compose.playground.test.yml \
+            logs --no-color --tail=300 || true

--- a/tests/fixtures/fake-claude.sh
+++ b/tests/fixtures/fake-claude.sh
@@ -1,30 +1,100 @@
 #!/bin/sh
 # tests/fixtures/fake-claude.sh —— CI 用的 claude CLI 占位可执行文件。
 #
-# 为什么需要它：app/src/server/app.js 的 preflight() 在找不到 claude 时 process.exit(1)，于是 21 个集成
-# 测试文件此前全带 `process.env.CI ? {skip}`，理由写的是「CI 无本机 claude CLI」。后果是 CI 里
-# 【没有任何 job 执行过真实后端接线】—— quality 是纯静态、unit-test 不加载 app/src/server/app.js、
-# e2e 打的是 tests/e2e/mock/server.js 而非真 server。仓库最大的两个文件（app/public/js/app.js 6960 行、
-# app/src/server/app.js 2966 行）在 CI 里零执行。
+# 默认模式只负责让真实 server 通过 preflight，并吞掉 SDK stdin；它绝不能伪造 turn，避免普通
+# integration 用例在不知道的情况下把「fake 成功」当成真实 Agent 行为。
 #
-# 但那个限制比看上去松得多：preflight 只要求 CLAUDE_BIN 指向一个存在的文件，并（可选地）能回
-# `--version`。真正需要跑 agent turn 的测试另有 RUN_CLAUDE_INTEGRATION 这道门把着——那才是
-# 「需要真 CLI」的正确判据。本 stub 让不需要 turn 的接线测试在 CI 跑起来，turn 类测试照旧跳过。
+# Playground 的 Browser -> Real App E2E 需要再往前走一层，验证真实 Socket/Agent 接线和消息渲染。
+# 只有显式设置 CCM_FAKE_CLAUDE_TURNS=1 时，才启用下面的最小 stream-json 协议：
+# initialize/user -> system:init + assistant + result。零 token、无网络、回复完全确定。
 #
-# 边界：它只应答 --version。任何真起 agent turn 的调用都会拿到这里的空输出而失败——这是有意的，
-# 失败即说明该测试被错误地归进了「不需要真 turn」那一类，应该给它加回 RUN_CLAUDE_INTEGRATION 门。
-#
-# ⚠️ 非 --version 分支必须【读完 stdin 再退出】，不能直接 exit 0。
-# 真 CLI 在 SDK 模式下是长驻的：SDK spawn 它之后立刻往 stdin 写控制消息。stub 若立即退出，
-# 管道读端已关闭，SDK 那次 write 抛 EPIPE —— 且它在 SDK 内部（sdk.mjs 的 xy.write）不被 catch，
-# 直接冒成 uncaughtException 打死整个测试进程。
-# 表现：config-refresh.test.mjs 在 CI 报 `before hook generated asynchronous activity after the
-# test ended`（客户端一连接、server 懒开 SDK 实例就触发，与该用例断言的行为无关）。
-# 本地不复现——本地 CLAUDE_BIN 指向真 claude，它不会提前关掉管道。
-# 这类接线测试无法避免 spawn：server 在客户端连接时就会懒开实例。所以 stub 得活着承受这次
-# spawn，安静吞掉输入、不产出任何响应（"拿到空输出而失败"的语义不变，只是失败方式从
-# 打死进程变回可控的等不到响应）。
+# ⚠️ 默认非 --version 分支必须读完 stdin 再退出，不能直接 exit 0。SDK 会在 spawn 后立刻写控制消息；
+# 提前关闭管道会触发 SDK 内部 EPIPE，把本来只想测接线的 integration 进程直接打死。
 case "$1" in
-  --version|-v) echo "0.0.0-fake (Claude Code CI stub)" ;;
-  *) cat > /dev/null 2>&1; exit 0 ;;
+  --version|-v)
+    echo "0.0.0-fake (Claude Code CI stub)"
+    ;;
+  *)
+    if [ "${CCM_FAKE_CLAUDE_TURNS:-}" = "1" ]; then
+      exec node --input-type=module -e '
+        import readline from "node:readline";
+        import { randomUUID } from "node:crypto";
+
+        const sessionId = randomUUID();
+        const model = "claude-fake-test";
+        let initialized = false;
+        let turn = 0;
+
+        const send = message => process.stdout.write(`${JSON.stringify(message)}\n`);
+        const sendInit = () => {
+          if (initialized) return;
+          initialized = true;
+          send({
+            type: "system", subtype: "init", session_id: sessionId,
+            apiKeySource: "none", cwd: process.cwd(), tools: [], mcp_servers: [],
+            model, permissionMode: "default", claude_code_version: "0.0.0-fake",
+            slash_commands: [], skills: [], agents: [], plugins: [],
+          });
+        };
+        const controlResponse = requestId => send({
+          type: "control_response",
+          response: { subtype: "success", request_id: requestId, response: {} },
+        });
+        const extractUserText = message => {
+          const content = message?.message?.content;
+          if (typeof content === "string") return content;
+          if (!Array.isArray(content)) return "";
+          return content
+            .filter(block => block && block.type === "text" && typeof block.text === "string")
+            .map(block => block.text)
+            .join("\n");
+        };
+        const completeTurn = userText => {
+          sendInit();
+          turn += 1;
+          const reply = `CCM deterministic fake reply: ${userText}`;
+          const usage = {
+            input_tokens: 1,
+            output_tokens: Math.max(1, reply.length),
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          };
+          send({
+            type: "assistant", session_id: sessionId, parent_tool_use_id: null, uuid: randomUUID(),
+            message: {
+              id: `msg_fake_${turn}`, type: "message", role: "assistant", model,
+              content: [{ type: "text", text: reply }], stop_reason: "end_turn",
+              stop_sequence: null, usage,
+            },
+          });
+          send({
+            type: "result", subtype: "success", is_error: false,
+            duration_ms: 1, duration_api_ms: 1, num_turns: 1, result: reply,
+            session_id: sessionId, total_cost_usd: 0, usage, modelUsage: {},
+            permission_denials: [], uuid: randomUUID(),
+          });
+        };
+
+        const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+        rl.on("line", line => {
+          if (!line.trim()) return;
+          let message;
+          try { message = JSON.parse(line); }
+          catch (error) {
+            process.stderr.write(`[fake-claude] invalid JSON: ${error.message}\n`);
+            process.exitCode = 1;
+            return;
+          }
+          if (message.type === "control_request") {
+            controlResponse(message.request_id);
+            if (message.request?.subtype === "initialize") sendInit();
+            return;
+          }
+          if (message.type === "user") completeTurn(extractUserText(message));
+        });
+      ' "$@"
+    fi
+    cat > /dev/null 2>&1
+    exit 0
+    ;;
 esac

--- a/tests/infra/docker-compose.playground.yml
+++ b/tests/infra/docker-compose.playground.yml
@@ -58,6 +58,8 @@ services:
       - playground/runtime.env
     environment:
       <<: *runtime-env
+      # 只给真实 app 启用 deterministic turn。probe/browser 继承基础环境但不应改变 fake CLI 语义。
+      CCM_FAKE_CLAUDE_TURNS: "1"
     volumes:
       - ../../app:/app/app
       - ../../scripts:/app/scripts

--- a/tests/playground/e2e/app-tofu.spec.ts
+++ b/tests/playground/e2e/app-tofu.spec.ts
@@ -50,6 +50,28 @@ test.describe.serial('playground app TOFU', () => {
     await expect(page.locator('#btnNew')).toBeVisible();
   });
 
+  test('first chat turn traverses browser -> real app -> Agent SDK -> deterministic Claude fixture -> browser', async () => {
+    const userText = 'hello from real app e2e';
+    const expectedReply = `CCM deterministic fake reply: ${userText}`;
+
+    await page.locator('#btnNew').click();
+    const input = page.locator('#input');
+    await expect(input).toBeVisible();
+    await expect(input).toBeEditable();
+    await input.fill(userText);
+
+    const send = page.locator('#btnSend');
+    await expect(send).toBeVisible();
+    await expect(send).toBeEnabled();
+    await send.click();
+
+    // 这两条一起证明不是浏览器本地造假：user bubble 先走 production socket，assistant 文本由
+    // deterministic stream-json CLI fixture 根据收到的 user payload 回显，再经 AgentSession 映射回浏览器。
+    await expect(page.locator('[data-testid="user-message"]').last()).toContainText(userText);
+    await expect(page.locator('[data-testid="assistant-message"]').last()).toContainText(expectedReply, { timeout: 15_000 });
+    await expect(send).not.toHaveAttribute('data-mode', 'stop', { timeout: 10_000 });
+  });
+
   test('workspace is the seeded container project', async () => {
     await page.locator('#btnSessions').click();
     await expect(page.locator(`#sessionPanel div[data-dir="${WORKSPACE}"]`)).toBeVisible();

--- a/tests/unit/playground-compose.test.mjs
+++ b/tests/unit/playground-compose.test.mjs
@@ -3,6 +3,7 @@
 // 这些断言锁的是「干净 Linux 用户」夹具不会吃进宿主机 ccm.config.json / .env / data/ / 秘密。
 // YAML 按原文扫，不 parse：${ 插值、列表式 environment、漏写的空键，parse 之后就看不见了。
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -18,6 +19,8 @@ const TEST_OVERRIDE = join(ROOT, 'tests/infra/docker-compose.playground.test.yml
 const TEST_COMPOSE = join(ROOT, 'tests/infra/docker-compose.test.yml');
 const RUNTIME_ENV = join(ROOT, 'tests/infra/playground/runtime.env');
 const PACKAGE_JSON = join(ROOT, 'package.json');
+const TEST_WORKFLOW = join(ROOT, '.github/workflows/test.yml');
+const FAKE_CLAUDE = join(ROOT, 'tests/fixtures/fake-claude.sh');
 
 const ANTHROPIC_KEYS = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_BASE_URL'];
 const YAML_EMPTY_OR_LITERAL = (key) => new RegExp(`^\\s+${key}:\\s*(?:""|''|\\S)`, 'm');
@@ -48,6 +51,15 @@ function serviceBlock(yaml, name) {
   return next === -1 ? rest : rest.slice(0, next);
 }
 
+function workflowJobBlock(yaml, name) {
+  const start = yaml.search(new RegExp(`^  ${name}:`, 'm'));
+  assert.notEqual(start, -1, `workflow 里没有 ${name} job`);
+  const header = `  ${name}:\n`;
+  const rest = yaml.slice(start + header.length);
+  const next = rest.search(/\n {2}[a-zA-Z][a-zA-Z0-9_-]*:/);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
 test('runtime.env 钉死隔离键，不把 HOME 当工作区，不设 CI', () => {
   const env = parseEnvFile(read(RUNTIME_ENV));
   assert.equal(env.AUTH_TOKEN, PLAYGROUND_TOKEN);
@@ -61,6 +73,7 @@ test('runtime.env 钉死隔离键，不把 HOME 当工作区，不设 CI', () =>
   assert.equal(env.CCM_TEST_PRESERVE_EMPTY_ENV, '1');
   assert.notEqual(env.DEV_MODE, '1');
   assert.equal(Object.hasOwn(env, 'CI'), false);
+  assert.equal(Object.hasOwn(env, 'CCM_FAKE_CLAUDE_TURNS'), false, 'deterministic turn 只能由 playground app 显式开启');
 
   for (const key of SPAWN_ENV_BLOCKLIST) {
     assert.equal(Object.hasOwn(env, key), true, `runtime.env 缺少 blocklist 键 ${key}`);
@@ -81,19 +94,12 @@ test('playground compose：镜像、端口、overlay、profiles、零插值、�
   assert.match(yaml, /127\.0\.0\.1:13100:3100/);
   assert.match(yaml, /127\.0\.0\.1:18080:8080/);
   assert.doesNotMatch(yaml, /^\s+-\s+["']?3000:3000["']?\s*$/m);
-  // Docker Desktop virtiofs 不能在 `.:/app` 上再叠 /app/.env（宿主机若已有该文件会
-  // OCI mount 失败）。隔离改成：不挂仓库根，只挂源码目录；配置由 entrypoint 写进容器层。
-  // 两种写法都要防：compose 移进 tests/infra/ 后，「挂仓库根」写出来是 `../..:/app` 而不再是 `.:/app`。
   assert.doesNotMatch(yaml, /^\s+-\s+["']?(?:\.|\.\.\/\.\.):\/app["']?\s*$/m);
   assert.doesNotMatch(yaml, /^\s+- .*:\/app\/\.env/m);
   assert.doesNotMatch(yaml, /^\s+- .*:\/app\/ccm\.config\.json/m);
-  // 运行时代码整体在 app/ 下，一条挂载即可；容器内路径与仓库结构一致（/app 恒等于仓库根）。
   assert.match(yaml, /\.\.\/\.\.\/app:\/app\/app/);
   assert.match(yaml, /\.\.\/\.\.\/scripts:\/app\/scripts/);
   assert.match(yaml, /\.\.\/\.\.\/tests:\/app\/tests/);
-  // 夹具（tests/infra/playground/）随 ../../tests 挂载一起进容器，不再单独挂一条。
-  // 所以这里断言的不是挂载，而是【容器里那条路径真能找到入口脚本】——挂载写对了但
-  // command 指向旧路径的话，容器会以 "No such file" 起不来，而挂载断言看不出来。
   assert.match(yaml, /\/app\/tests\/infra\/playground\/entrypoint-app\.sh/);
   assert.doesNotMatch(yaml, /\$\{/);
   assert.doesNotMatch(yaml, /env_file:\s*\.env\b/);
@@ -106,6 +112,7 @@ test('playground compose：镜像、端口、overlay、profiles、零插值、�
 
   const app = serviceBlock(yaml, 'app');
   assert.match(app, /init:\s*true/);
+  assert.match(app, /^\s+CCM_FAKE_CLAUDE_TURNS:\s*"1"\s*$/m);
   assert.doesNotMatch(app, /^\s+profiles:/m);
 
   for (const name of ['mock', 'proxy', 'probe', 'browser']) {
@@ -122,6 +129,44 @@ test('playground compose：镜像、端口、overlay、profiles、零插值、�
   for (const name of ['app', 'probe', 'browser']) {
     assert.match(serviceBlock(yaml, name), /playground-home/, `${name} 必须挂 playground-home（或同名数据卷）`);
   }
+});
+
+test('fake Claude 默认静默，只有显式 turn 模式才完成 initialize + user 回合', () => {
+  const version = spawnSync(FAKE_CLAUDE, ['--version'], { cwd: ROOT, encoding: 'utf8' });
+  assert.equal(version.status, 0, version.stderr);
+  assert.match(version.stdout, /0\.0\.0-fake/);
+
+  const userText = 'hello deterministic fake';
+  const input = [
+    JSON.stringify({ type: 'control_request', request_id: 'req-init', request: { subtype: 'initialize' } }),
+    JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: userText }] } }),
+    '',
+  ].join('\n');
+
+  const silent = spawnSync(FAKE_CLAUDE, ['--output-format', 'stream-json'], {
+    cwd: ROOT,
+    input,
+    encoding: 'utf8',
+    timeout: 5_000,
+    env: { ...process.env, CCM_FAKE_CLAUDE_TURNS: '' },
+  });
+  assert.equal(silent.status, 0, silent.stderr);
+  assert.equal(silent.stdout, '');
+
+  const turn = spawnSync(FAKE_CLAUDE, ['--output-format', 'stream-json', '--input-format', 'stream-json', '--verbose'], {
+    cwd: ROOT,
+    input,
+    encoding: 'utf8',
+    timeout: 5_000,
+    env: { ...process.env, CCM_FAKE_CLAUDE_TURNS: '1' },
+  });
+  assert.equal(turn.status, 0, turn.stderr);
+  const messages = turn.stdout.trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+  const init = messages.find(message => message.type === 'system' && message.subtype === 'init');
+  assert.equal(init?.model, 'claude-fake-test');
+  assert.equal(messages.find(message => message.type === 'assistant')?.message?.content?.[0]?.text,
+    `CCM deterministic fake reply: ${userText}`);
+  assert.equal(messages.find(message => message.type === 'result')?.subtype, 'success');
 });
 
 test('test compose 仍不发端口，并与 playground 共享 ccm-test:local 标签', () => {
@@ -142,6 +187,14 @@ test('package.json 有 test:docker:playground、没有宿主机原生 test:playg
   const scripts = JSON.parse(read(PACKAGE_JSON)).scripts;
   assert.equal(Object.hasOwn(scripts, 'test:docker:playground'), true);
   assert.equal(Object.hasOwn(scripts, 'test:playground'), false);
+});
+
+test('GitHub CI 必须持续执行真实 app playground，而不是只靠维护者手工运行', () => {
+  const yaml = read(TEST_WORKFLOW);
+  const job = workflowJobBlock(yaml, 'real-app-e2e');
+  assert.match(job, /runs-on:\s*ubuntu-latest/);
+  assert.match(job, /npm run test:docker:playground/);
+  assert.doesNotMatch(job, /continue-on-error:\s*true/);
 });
 
 test('inventory 认得 playground 树', () => {


### PR DESCRIPTION
基于 `dev@439bb02`，把现有 Playground 真实应用验收提升为持续 CI，并补上第一条真实聊天主链。

- CI 新增 `real-app-e2e`，执行 `npm run test:docker:playground`
- Browser → real `app/server.js` → real HTTP/Socket/TOFU/device/workspace
- `fake-claude.sh` 默认仍静默；仅 app service 显式 `CCM_FAKE_CLAUDE_TURNS=1` 时启用 deterministic stream-json turn
- 主链验证：浏览器发消息 → production server → Agent SDK → fake CLI → assistant/result → 浏览器渲染
- 全程零 token、无 Anthropic 凭据
- unit 契约锁住 fake CLI 默认/turn 两种语义以及 CI real-app lane，防以后回退

本 PR 不替代既有 Mock E2E；它补的是 Mock Browser E2E 与真实 Server Integration 之间的真实产品接线层。